### PR TITLE
Add lifestyle data config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a personal blog website built with Next.js, Tailwind CSS, and Shadcn UI.
 -   **Portfolio Section**: Showcase your projects.
 -   **Resume Section**: Display your professional resume.
 -   **JSON Configuration**: All site and Nostr settings are stored in `settings.json` at the project root.
--   **Lifestyle Tracking**: (Planned/Partial) Sections for workouts, nutrition, biohacks, and routines.
+-   **Lifestyle Tracking**: Sections for workouts, nutrition, biohacks, and routines. Data is loaded from `lib/lifestyle-config.json`.
 
 ## Getting Started
 
@@ -55,6 +55,7 @@ This is a personal blog website built with Next.js, Tailwind CSS, and Shadcn UI.
 -   **Styling**: Modify `app/globals.css` and `tailwind.config.ts` for theme and custom styles.
 -   **Nostr Relays**: Adjust the list of relays in `lib/nostr.ts` to connect to your preferred Nostr relays.
 -   **Content**: Your blog content is fetched directly from your Nostr public key. Publish NIP-23 long-form events or NIP-01 notes to your configured relays.
+-   **Lifestyle Data**: Edit `lib/lifestyle-config.json` to set your own workouts, nutrition entries, biohacks, and routines. These are displayed on the Lifestyle page alongside your latest `#lifestyle` posts.
 
 ## Contributing
 

--- a/app/lifestyle/page.tsx
+++ b/app/lifestyle/page.tsx
@@ -74,7 +74,7 @@ export default function LifestylePage() {
   const [newWorkoutName, setNewWorkoutName] = useState("")
 
   const [meals, setMeals] = useState<Meal[]>(
-    lifestyleConfig.meals as Meal[],
+    lifestyleConfig.nutrition as Meal[],
   )
   const [newMeal, setNewMeal] = useState({ name: "", calories: 0, protein: 0, carbs: 0, fat: 0 })
 
@@ -84,10 +84,10 @@ export default function LifestylePage() {
   const [newBiohackName, setNewBiohackName] = useState("")
 
   const [morningRoutine, setMorningRoutine] = useState<RoutineItem[]>(
-    lifestyleConfig.morningRoutine as RoutineItem[],
+    lifestyleConfig.routines.morning as RoutineItem[],
   )
   const [eveningRoutine, setEveningRoutine] = useState<RoutineItem[]>(
-    lifestyleConfig.eveningRoutine as RoutineItem[],
+    lifestyleConfig.routines.evening as RoutineItem[],
   )
   const [newMorningRoutineItem, setNewMorningRoutineItem] = useState("")
   const [newEveningRoutineItem, setNewEveningRoutineItem] = useState("")

--- a/lib/lifestyle-config.json
+++ b/lib/lifestyle-config.json
@@ -4,21 +4,37 @@
     { "id": "2", "name": "Strength Training (Upper Body)", "completed": true },
     { "id": "3", "name": "Yoga (20 min)", "completed": false }
   ],
-  "meals": [
-    { "id": "m1", "name": "Oatmeal with Berries", "calories": 350, "protein": 15, "carbs": 50, "fat": 10 },
-    { "id": "m2", "name": "Chicken Salad", "calories": 450, "protein": 40, "carbs": 20, "fat": 25 }
+  "nutrition": [
+    {
+      "id": "m1",
+      "name": "Oatmeal with Berries",
+      "calories": 350,
+      "protein": 15,
+      "carbs": 50,
+      "fat": 10
+    },
+    {
+      "id": "m2",
+      "name": "Chicken Salad",
+      "calories": 450,
+      "protein": 40,
+      "carbs": 20,
+      "fat": 25
+    }
   ],
   "biohacks": [
     { "id": "b1", "name": "Cold Shower (5 min)", "completed": false },
     { "id": "b2", "name": "Intermittent Fasting (16/8)", "completed": true }
   ],
-  "morningRoutine": [
-    { "id": "mr1", "name": "Meditate (10 min)", "completed": false },
-    { "id": "mr2", "name": "Journaling", "completed": false },
-    { "id": "mr3", "name": "Hydrate (500ml water)", "completed": true }
-  ],
-  "eveningRoutine": [
-    { "id": "er1", "name": "Read (30 min)", "completed": false },
-    { "id": "er2", "name": "Prepare for next day", "completed": false }
-  ]
+  "routines": {
+    "morning": [
+      { "id": "mr1", "name": "Meditate (10 min)", "completed": false },
+      { "id": "mr2", "name": "Journaling", "completed": false },
+      { "id": "mr3", "name": "Hydrate (500ml water)", "completed": true }
+    ],
+    "evening": [
+      { "id": "er1", "name": "Read (30 min)", "completed": false },
+      { "id": "er2", "name": "Prepare for next day", "completed": false }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- restructure `lib/lifestyle-config.json` to expose `workouts`, `nutrition`, `biohacks`, and grouped `routines`
- load the new config fields in the Lifestyle page
- document how to edit the lifestyle configuration in the README

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pnpm lint` *(fails: cannot download pnpm due to network restrictions)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688801a000dc8326a0eded74eaa52ba1