### PR TITLE
Add emoji icon and SEO metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,20 @@ export const metadata: Metadata = {
   title: settings.siteName,
   description: settings.siteDescription,
   generator: "v0.dev",
+  icons: {
+    icon: "/icon.svg",
+  },
+  openGraph: {
+    title: settings.siteName,
+    description: settings.siteDescription,
+    images: ["/icon.svg"],
+  },
+  twitter: {
+    card: "summary",
+    title: settings.siteName,
+    description: settings.siteDescription,
+    images: ["/icon.svg"],
+  },
 }
 
 export default function RootLayout({

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <text x="32" y="48" font-size="48" text-anchor="middle">🧘🏼‍♂️</text>
+</svg>


### PR DESCRIPTION
## Summary
- create `public/icon.svg` with a yoga emoji
- expand `app/layout.tsx` metadata to reference the icon and provide basic Open Graph and Twitter meta fields

## Testing
- `npx next lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_68880d559a1883269315d5cb64017c9c