### PR TITLE
Add simple navbar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import "./globals.css"
 // import { Navigation } from "@/components/navigation"
 // import { Footer } from "@/components/footer"
 // import { Toaster } from "@/components/ui/toaster"
+import { Navbar } from "@/components/navbar"
 import { getSettings } from "@/lib/settings"
 
 const inter = Inter({ subsets: ["latin"] })
@@ -44,16 +45,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-        {/*
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-          <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-            <Navigation />
-            <main className="container mx-auto px-4 py-8">{children}</main>
-            <Footer />
-          </div>
-          <Toaster />
-        </ThemeProvider>
-        */}
+        <Navbar />
         {children}
       </body>
     </html>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link"
+import { getSettings } from "@/lib/settings"
+
+const links = [
+  { name: "Home", href: "/" },
+  { name: "Blog", href: "/blog" },
+  { name: "Portfolio", href: "/portfolio" },
+  { name: "Resume", href: "/resume" },
+  { name: "Lifestyle", href: "/lifestyle" },
+  { name: "Contact", href: "/contact" },
+]
+
+const settings = getSettings()
+
+export function Navbar() {
+  return (
+    <nav className="border-b bg-background">
+      <div className="container flex flex-wrap gap-4 py-4">
+        <Link href="/" className="font-bold">
+          {settings.siteName}
+        </Link>
+        {links.map((link) => (
+          <Link key={link.href} href={link.href} className="text-sm text-muted-foreground hover:text-foreground">
+            {link.name}
+          </Link>
+        ))}
+      </div>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- add a new `Navbar` component with basic links
- include `Navbar` in the site layout

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68882d4bb4a08326bf987b6955ad7744