### PR TITLE
Fix viewport export

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import type { Metadata } from "next"
+import type { Metadata, Viewport } from "next"
 import { Inter } from "next/font/google"
 import "./globals.css"
 // import { ThemeProvider } from "@/components/theme-provider"
@@ -13,13 +13,14 @@ const inter = Inter({ subsets: ["latin"] })
 
 const settings = getSettings()
 
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+}
+
 export const metadata: Metadata = {
   title: settings.siteName,
   description: settings.siteDescription,
-  viewport: {
-    width: "device-width",
-    initialScale: 1,
-  },
   generator: "v0.dev",
   icons: {
     icon: "/icon.svg",


### PR DESCRIPTION
## Summary
- fix Next.js 14 metadata warning by moving viewport into its own export

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_688a491907748326b56ba5ad44bfe0b0