### PR TITLE
Improve navbar and homepage layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -131,8 +131,8 @@ export default function HomePage() {
           {/* Profile skeleton */}
           <Card className="mb-8 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
             <CardContent className="p-8">
-              <div className="flex flex-col md:flex-row items-center md:items-start gap-6">
-                <Skeleton className="h-32 w-32 rounded-full" />
+              <div className="flex flex-col md:flex-row items-center md:items-center gap-8">
+                <Skeleton className="h-48 w-48 rounded-full" />
                 <div className="flex-1 space-y-4 text-center md:text-left">
                   <Skeleton className="h-8 w-48 mx-auto md:mx-0" />
                   <Skeleton className="h-4 w-full max-w-md mx-auto md:mx-0" />
@@ -195,8 +195,8 @@ export default function HomePage() {
         {profile && (
           <Card className="mb-8 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm hover:shadow-xl transition-all duration-300">
             <CardContent className="p-8">
-              <div className="flex flex-col md:flex-row items-center md:items-start gap-6">
-                <Avatar className="h-32 w-32 border-4 border-white dark:border-slate-700 shadow-lg">
+              <div className="flex flex-col md:flex-row items-center md:items-center gap-8">
+                <Avatar className="h-48 w-48 border-4 border-white dark:border-slate-700 shadow-lg">
                   <AvatarImage
                     src={profile.picture || "/placeholder.svg"}
                     alt={profile.name || profile.display_name || "Profile"}
@@ -279,6 +279,7 @@ export default function HomePage() {
         </Card>
 
         {/* Posts */}
+        <h2 className="text-2xl font-bold mb-4">Latest Posts</h2>
         <div className="space-y-6">
           {filteredPosts.length === 0 ? (
             <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -15,15 +15,21 @@ const settings = getSettings()
 export function Navbar() {
   return (
     <nav className="border-b bg-background">
-      <div className="container flex flex-wrap gap-4 py-4">
+      <div className="container flex items-center gap-4 py-4">
         <Link href="/" className="font-bold">
           {settings.siteName}
         </Link>
-        {links.map((link) => (
-          <Link key={link.href} href={link.href} className="text-sm text-muted-foreground hover:text-foreground">
-            {link.name}
-          </Link>
-        ))}
+        <div className="ml-auto flex flex-wrap gap-4 text-sm">
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              {link.name}
+            </Link>
+          ))}
+        </div>
       </div>
     </nav>
   )

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -14,7 +14,9 @@ export interface Settings {
 import config from "@/settings.json";
 
 export function getSettings(): Settings {
-  return (config as any).site as Settings;
+  const site = (config as any).site as Settings;
+  const npub = (config as any).nostr.ownerNpub as string;
+  return { ...site, siteName: npub };
 }
 
 // Placeholder to keep API compatibility

--- a/settings.json
+++ b/settings.json
@@ -2,7 +2,7 @@
   "site": {
     "showResume": true,
     "showLifestyle": true,
-    "siteName": "My Personal Blog",
+    "siteName": "npub1m9vsm9d8sy0pevcjhenwm4ny6l37dm2hsg4dnusna43ql3n5305qy4zlg4",
     "siteDescription": "A personal blog powered by Nostr",
     "contactEmail": "",
     "socialLinks": {


### PR DESCRIPTION
## Summary
- set navbar links to the right
- derive site name from the tracked npub
- enlarge profile picture and center layout
- show a *Latest Posts* heading on the homepage

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_688a8d42beb08326b00f9ebba86ee20a