### PR TITLE
Improve navbar and homepage layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -131,8 +131,8 @@ export default function HomePage() {
           {/* Profile skeleton */}
           <Card className="mb-8 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
             <CardContent className="p-8">
-              <div className="flex flex-col md:flex-row items-center md:items-start gap-6">
-                <Skeleton className="h-32 w-32 rounded-full" />
+              <div className="flex flex-col md:flex-row items-center md:items-center gap-6">
+                <Skeleton className="h-48 w-48 rounded-full" />
                 <div className="flex-1 space-y-4 text-center md:text-left">
                   <Skeleton className="h-8 w-48 mx-auto md:mx-0" />
                   <Skeleton className="h-4 w-full max-w-md mx-auto md:mx-0" />
@@ -195,8 +195,8 @@ export default function HomePage() {
         {profile && (
           <Card className="mb-8 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm hover:shadow-xl transition-all duration-300">
             <CardContent className="p-8">
-              <div className="flex flex-col md:flex-row items-center md:items-start gap-6">
-                <Avatar className="h-32 w-32 border-4 border-white dark:border-slate-700 shadow-lg">
+              <div className="flex flex-col md:flex-row items-center md:items-center gap-6">
+                <Avatar className="h-48 w-48 border-4 border-white dark:border-slate-700 shadow-lg">
                   <AvatarImage
                     src={profile.picture || "/placeholder.svg"}
                     alt={profile.name || profile.display_name || "Profile"}
@@ -279,6 +279,7 @@ export default function HomePage() {
         </Card>
 
         {/* Posts */}
+        <h2 className="text-2xl font-bold mb-4">Latest Posts</h2>
         <div className="space-y-6">
           {filteredPosts.length === 0 ? (
             <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,5 +1,10 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import Link from "next/link"
 import { getSettings } from "@/lib/settings"
+import { getNostrSettings } from "@/lib/nostr-settings"
+import { fetchNostrProfile } from "@/lib/nostr"
 
 const links = [
   { name: "Home", href: "/" },
@@ -13,17 +18,36 @@ const links = [
 const settings = getSettings()
 
 export function Navbar() {
+  const [siteName, setSiteName] = useState(settings.siteName)
+
+  useEffect(() => {
+    const nostrSettings = getNostrSettings()
+    if (!nostrSettings.ownerNpub) return
+
+    fetchNostrProfile(nostrSettings.ownerNpub).then((profile) => {
+      const name =
+        profile?.display_name || profile?.name || nostrSettings.ownerNpub
+      if (name) setSiteName(name)
+    })
+  }, [])
+
   return (
     <nav className="border-b bg-background">
-      <div className="container flex flex-wrap gap-4 py-4">
+      <div className="container flex flex-wrap items-center justify-between py-4">
         <Link href="/" className="font-bold">
-          {settings.siteName}
+          {siteName}
         </Link>
-        {links.map((link) => (
-          <Link key={link.href} href={link.href} className="text-sm text-muted-foreground hover:text-foreground">
-            {link.name}
-          </Link>
-        ))}
+        <div className="flex flex-wrap gap-4 ml-auto">
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="text-sm text-muted-foreground hover:text-foreground"
+            >
+              {link.name}
+            </Link>
+          ))}
+        </div>
       </div>
     </nav>
   )


### PR DESCRIPTION
## Summary
- fetch the tracked npub's profile name for the navbar
- align the nav links to the right
- enlarge profile picture on the home page and center it next to the bio
- add "Latest Posts" heading

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a8d42beb08326b00f9ebba86ee20a