### PR TITLE
Improve blog layout and navbar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,8 @@ import "./globals.css"
 // import { Toaster } from "@/components/ui/toaster"
 import { Navbar } from "@/components/navbar"
 import { getSettings } from "@/lib/settings"
+import { getNostrSettings } from "@/lib/nostr-settings"
+import { fetchNostrProfile } from "@/lib/nostr"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -38,15 +40,24 @@ export const metadata: Metadata = {
   },
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const npub = getNostrSettings().ownerNpub
+  let siteName = settings.siteName
+  if (npub) {
+    const profile = await fetchNostrProfile(npub)
+    siteName =
+      profile?.display_name || profile?.name || profile?.nip05?.split("@")[0] ||
+      siteName
+  }
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-        <Navbar />
+        <Navbar siteName={siteName} />
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -195,8 +195,8 @@ export default function HomePage() {
         {profile && (
           <Card className="mb-8 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm hover:shadow-xl transition-all duration-300">
             <CardContent className="p-8">
-              <div className="flex flex-col md:flex-row items-center md:items-start gap-6">
-                <Avatar className="h-32 w-32 border-4 border-white dark:border-slate-700 shadow-lg">
+              <div className="flex flex-col md:flex-row items-center md:items-center gap-6">
+                <Avatar className="h-48 w-48 border-4 border-white dark:border-slate-700 shadow-lg">
                   <AvatarImage
                     src={profile.picture || "/placeholder.svg"}
                     alt={profile.name || profile.display_name || "Profile"}
@@ -279,6 +279,7 @@ export default function HomePage() {
         </Card>
 
         {/* Posts */}
+        <h2 className="text-2xl font-bold mb-4">Latest Posts</h2>
         <div className="space-y-6">
           {filteredPosts.length === 0 ? (
             <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import Link from "next/link"
 import { getSettings } from "@/lib/settings"
 
@@ -12,18 +14,25 @@ const links = [
 
 const settings = getSettings()
 
-export function Navbar() {
+export function Navbar({ siteName = settings.siteName }: { siteName?: string }) {
+
   return (
     <nav className="border-b bg-background">
-      <div className="container flex flex-wrap gap-4 py-4">
+      <div className="container flex flex-wrap items-center justify-between gap-4 py-4">
         <Link href="/" className="font-bold">
-          {settings.siteName}
+          {siteName}
         </Link>
-        {links.map((link) => (
-          <Link key={link.href} href={link.href} className="text-sm text-muted-foreground hover:text-foreground">
-            {link.name}
-          </Link>
-        ))}
+        <div className="flex flex-wrap gap-4 text-sm">
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              {link.name}
+            </Link>
+          ))}
+        </div>
       </div>
     </nav>
   )


### PR DESCRIPTION
## Summary
- fetch npub profile in layout and send name to navbar
- make navbar links align right
- enlarge and center profile picture
- show heading for latest posts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a8d42beb08326b00f9ebba86ee20a