### PR TITLE
Add mobile menu toggle

### DIFF
--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -18,7 +18,7 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
   })
   const html = marked.parse(content)
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="w-full px-4 py-8">
       <h1 className="text-3xl font-bold mb-4">{note.title}</h1>
       <div className="prose dark:prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: html }} />
       <div className="mt-8">

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -4,7 +4,7 @@ import { getAllNotes } from '@/lib/digital-garden'
 export default async function DigitalGardenPage() {
   const notes = await getAllNotes()
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="w-full px-4 py-8">
       <h1 className="text-4xl font-bold mb-4">Digital Garden</h1>
       <ul className="list-disc pl-5 space-y-2">
         {notes.map((note) => (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -127,7 +127,7 @@ export default function HomePage() {
   if (loading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-        <div className="container mx-auto px-4 py-8">
+        <div className="w-full px-4 py-8">
           {/* Profile skeleton */}
           <Card className="mb-8 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
             <CardContent className="p-8">
@@ -171,7 +171,7 @@ export default function HomePage() {
   if (error) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-        <div className="container mx-auto px-4 py-8">
+        <div className="w-full px-4 py-8">
           <Alert className="max-w-2xl mx-auto">
             <AlertDescription className="flex items-center justify-between">
               <span>{error}</span>
@@ -190,7 +190,7 @@ export default function HomePage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-      <div className="container mx-auto px-4 py-8">
+      <div className="w-full px-4 py-8">
         {/* Profile Section */}
         {profile && (
           <Card className="mb-8 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm hover:shadow-xl transition-all duration-300">

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -45,20 +45,20 @@ export function Navbar() {
             <Button
               variant="ghost"
               size="icon"
-              className="ml-auto md:hidden"
+              className="ml-auto h-10 w-10 md:hidden"
             >
-              <Menu className="h-5 w-5" />
+              <Menu className="h-6 w-6" />
               <span className="sr-only">Open Menu</span>
             </Button>
           </SheetTrigger>
-          <SheetContent side="left" className="pr-0">
-            <div className="mt-4 flex flex-col space-y-4 pl-6">
+          <SheetContent side="left" className="w-[90%] pr-0 sm:max-w-xs">
+            <div className="mt-4 flex flex-col space-y-2 pl-6">
               {links.map((link) => (
                 <Link
                   key={link.href}
                   href={link.href}
                   onClick={() => setOpen(false)}
-                  className="text-muted-foreground hover:text-foreground"
+                  className="py-2 text-lg text-muted-foreground hover:text-foreground"
                 >
                   {link.name}
                 </Link>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,4 +1,10 @@
+"use client"
+
+import { useState } from "react"
 import Link from "next/link"
+import { Menu } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { getSettings } from "@/lib/settings"
 
 const links = [
@@ -13,13 +19,16 @@ const links = [
 const settings = getSettings()
 
 export function Navbar() {
+  const [open, setOpen] = useState(false)
+
   return (
     <nav className="border-b bg-background">
       <div className="container flex items-center gap-4 py-4">
         <Link href="/" className="font-bold">
           {settings.siteName}
         </Link>
-        <div className="ml-auto flex flex-wrap gap-4 text-sm">
+        {/* Desktop links */}
+        <div className="ml-auto hidden flex-wrap gap-4 text-sm md:flex">
           {links.map((link) => (
             <Link
               key={link.href}
@@ -30,6 +39,33 @@ export function Navbar() {
             </Link>
           ))}
         </div>
+        {/* Mobile menu toggle */}
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="ml-auto md:hidden"
+            >
+              <Menu className="h-5 w-5" />
+              <span className="sr-only">Open Menu</span>
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left" className="pr-0">
+            <div className="mt-4 flex flex-col space-y-4 pl-6">
+              {links.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  onClick={() => setOpen(false)}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  {link.name}
+                </Link>
+              ))}
+            </div>
+          </SheetContent>
+        </Sheet>
       </div>
     </nav>
   )


### PR DESCRIPTION
## Summary
- add client-side state to `Navbar`
- show nav links on desktop only
- add hamburger sheet menu for mobile

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a9379e2e08326af58114e8f1c4925