### PR TITLE
Refine mobile layout

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -15,7 +15,7 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
 
   if (!settings.ownerNpub || !settings.ownerNpub.startsWith("npub1")) {
     return (
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto py-8">
         <Card className="border-destructive max-w-md mx-auto">
           <CardContent className="pt-6 text-center">
             <div className="text-destructive text-4xl mb-4">⚠️</div>
@@ -53,7 +53,7 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
   const renderedContent = marked.parse(post.content || "")
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto py-8">
       <Card className="max-w-3xl mx-auto">
         <CardHeader>
           <div className="flex items-center justify-between mb-2">

--- a/app/blog/loading.tsx
+++ b/app/blog/loading.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card"
 
 export default function BlogLoading() {
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto py-8">
       <div className="animate-pulse">
         <div className="mb-8 h-10 w-64 rounded bg-muted"></div> {/* Title placeholder */}
         <div className="mb-6 flex space-x-4">

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -111,7 +111,7 @@ export default function BlogPage() {
   if (loading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-        <div className="container mx-auto px-4 py-8">
+        <div className="container mx-auto py-8">
           <div className="mb-8">
             <h1 className="text-4xl font-bold mb-4 bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
               Blog Posts
@@ -147,7 +147,7 @@ export default function BlogPage() {
   if (error) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-        <div className="container mx-auto px-4 py-8">
+        <div className="container mx-auto py-8">
           <div className="mb-8">
             <h1 className="text-4xl font-bold mb-4 bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
               Blog Posts
@@ -172,7 +172,7 @@ export default function BlogPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto py-8">
         {/* Header */}
         <div className="mb-8">
           <h1 className="text-4xl font-bold mb-4 bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -84,7 +84,7 @@ ${formData.message}`
   if (isSubmitted) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-        <div className="container mx-auto px-4 py-8">
+        <div className="container mx-auto py-8">
           <Card className="max-w-2xl mx-auto backdrop-blur-sm bg-white/80 dark:bg-slate-800/80 border-0 shadow-xl">
             <CardContent className="p-8 text-center">
               <CheckCircle className="h-16 w-16 text-green-500 mx-auto mb-4" />
@@ -104,7 +104,7 @@ ${formData.message}`
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto py-8">
         <Card className="max-w-2xl mx-auto backdrop-blur-sm bg-white/80 dark:bg-slate-800/80 border-0 shadow-xl">
           <CardHeader className="text-center">
             <CardTitle className="text-3xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent flex items-center justify-center gap-2">

--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -18,7 +18,7 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
   })
   const html = marked.parse(content)
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto py-8">
       <h1 className="text-3xl font-bold mb-4">{note.title}</h1>
       <div className="prose dark:prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: html }} />
       <div className="mt-8">

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -4,7 +4,7 @@ import { getAllNotes } from '@/lib/digital-garden'
 export default async function DigitalGardenPage() {
   const notes = await getAllNotes()
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto py-8">
       <h1 className="text-4xl font-bold mb-4">Digital Garden</h1>
       <ul className="list-disc pl-5 space-y-2">
         {notes.map((note) => (

--- a/app/lifestyle/page.tsx
+++ b/app/lifestyle/page.tsx
@@ -74,7 +74,7 @@ export default function LifestylePage() {
   }, [])
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto py-8">
       <h1 className="text-4xl font-bold mb-8 text-center">Lifestyle</h1>
       <Tabs defaultValue="posts" className="w-full">
         <TabsList className="grid w-full grid-cols-5">

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card"
 export default function Loading() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto py-8">
         {/* Profile skeleton */}
         <Card className="mb-8 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
           <CardContent className="p-8">

--- a/app/nostr-settings/page.tsx
+++ b/app/nostr-settings/page.tsx
@@ -118,7 +118,7 @@ export default function NostrSettingsPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto py-8">
         <Card className="max-w-4xl mx-auto backdrop-blur-sm bg-white/80 dark:bg-slate-800/80 border-0 shadow-xl">
           <CardHeader className="text-center">
             <CardTitle className="text-3xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent flex items-center justify-center gap-2">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -127,7 +127,7 @@ export default function HomePage() {
   if (loading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-        <div className="container mx-auto px-4 py-8">
+        <div className="container mx-auto py-8">
           {/* Profile skeleton */}
           <Card className="mb-8 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
             <CardContent className="p-8">
@@ -171,7 +171,7 @@ export default function HomePage() {
   if (error) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-        <div className="container mx-auto px-4 py-8">
+        <div className="container mx-auto py-8">
           <Alert className="max-w-2xl mx-auto">
             <AlertDescription className="flex items-center justify-between">
               <span>{error}</span>
@@ -190,7 +190,7 @@ export default function HomePage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto py-8">
         {/* Profile Section */}
         {profile && (
           <Card className="mb-8 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm hover:shadow-xl transition-all duration-300">

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -48,7 +48,7 @@ export default function PortfolioPage() {
   ]
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto py-8">
       <h1 className="text-4xl font-bold mb-8 text-center">My Portfolio</h1>
       <p className="text-xl text-muted-foreground text-center mb-12">
         A collection of my work, showcasing various technologies and problem-solving approaches.

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -6,7 +6,7 @@ import { Download, Mail, Phone, MapPin, Linkedin, Github } from "lucide-react"
 
 export default function ResumePage() {
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto py-8">
       <Card className="max-w-4xl mx-auto p-6">
         <CardHeader className="text-center">
           <CardTitle className="text-4xl font-bold mb-2">John Doe</CardTitle>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -82,7 +82,7 @@ export default function SettingsPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto py-8">
         <Card className="max-w-4xl mx-auto backdrop-blur-sm bg-white/80 dark:bg-slate-800/80 border-0 shadow-xl">
           <CardHeader className="text-center">
             <CardTitle className="text-3xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent flex items-center justify-center gap-2">

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,4 +1,10 @@
+"use client"
+
+import { useState } from "react"
 import Link from "next/link"
+import { Menu } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { getSettings } from "@/lib/settings"
 
 const links = [
@@ -13,13 +19,16 @@ const links = [
 const settings = getSettings()
 
 export function Navbar() {
+  const [open, setOpen] = useState(false)
+
   return (
     <nav className="border-b bg-background">
       <div className="container flex items-center gap-4 py-4">
         <Link href="/" className="font-bold">
           {settings.siteName}
         </Link>
-        <div className="ml-auto flex flex-wrap gap-4 text-sm">
+        {/* Desktop links */}
+        <div className="ml-auto hidden flex-wrap gap-4 text-sm md:flex">
           {links.map((link) => (
             <Link
               key={link.href}
@@ -30,6 +39,33 @@ export function Navbar() {
             </Link>
           ))}
         </div>
+        {/* Mobile menu toggle */}
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="ml-auto h-12 w-12 md:hidden"
+            >
+              <Menu className="h-6 w-6" />
+              <span className="sr-only">Open Menu</span>
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left" className="w-[90vw] pr-0">
+            <div className="mt-4 flex flex-col space-y-4 pl-6">
+              {links.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  onClick={() => setOpen(false)}
+                  className="text-lg leading-none py-3 text-muted-foreground hover:text-foreground"
+                >
+                  {link.name}
+                </Link>
+              ))}
+            </div>
+          </SheetContent>
+        </Sheet>
       </div>
     </nav>
   )

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,7 +13,7 @@ const config = {
   theme: {
     container: {
       center: true,
-      padding: "2rem",
+      padding: "1rem",
       screens: {
         "2xl": "1400px",
       },


### PR DESCRIPTION
## Summary
- reduce default container padding
- remove extra page padding for better mobile width
- expand mobile menu and larger touch targets

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a9379e2e08326af58114e8f1c4925