### PR TITLE
Replace default npub with user name

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,46 +7,50 @@ import "./globals.css"
 // import { Footer } from "@/components/footer"
 // import { Toaster } from "@/components/ui/toaster"
 import { Navbar } from "@/components/navbar"
-import { getSettings } from "@/lib/settings"
+import { getSettings, getSiteName } from "@/lib/settings"
 
 const inter = Inter({ subsets: ["latin"] })
 
-const settings = getSettings()
 
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
 }
 
-export const metadata: Metadata = {
-  title: settings.siteName,
-  description: settings.siteDescription,
-  generator: "v0.dev",
-  icons: {
-    icon: "/icon.svg",
-  },
-  openGraph: {
-    title: settings.siteName,
+export async function generateMetadata(): Promise<Metadata> {
+  const settings = getSettings()
+  const siteName = await getSiteName()
+  return {
+    title: siteName,
     description: settings.siteDescription,
-    images: ["/icon.svg"],
-  },
-  twitter: {
-    card: "summary",
-    title: settings.siteName,
-    description: settings.siteDescription,
-    images: ["/icon.svg"],
-  },
+    generator: "v0.dev",
+    icons: {
+      icon: "/icon.svg",
+    },
+    openGraph: {
+      title: siteName,
+      description: settings.siteDescription,
+      images: ["/icon.svg"],
+    },
+    twitter: {
+      card: "summary",
+      title: siteName,
+      description: settings.siteDescription,
+      images: ["/icon.svg"],
+    },
+  }
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const siteName = await getSiteName()
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-        <Navbar />
+        <Navbar siteName={siteName} />
         {children}
       </body>
     </html>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,12 +1,12 @@
-import { getSettings } from "@/lib/settings"
+interface FooterProps {
+  siteName: string
+}
 
-const settings = getSettings()
-
-export function Footer() {
+export function Footer({ siteName }: FooterProps) {
   return (
     <footer className="border-t py-6 text-center text-sm text-muted-foreground">
       <div className="container mx-auto px-4">
-        <p>&copy; {new Date().getFullYear()} {settings.siteName}. All rights reserved.</p>
+        <p>&copy; {new Date().getFullYear()} {siteName}. All rights reserved.</p>
         <p className="mt-1">Powered by Nostr and Next.js</p>
       </div>
     </footer>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,5 +1,8 @@
 import Link from "next/link"
-import { getSettings } from "@/lib/settings"
+
+interface NavbarProps {
+  siteName: string
+}
 
 const links = [
   { name: "Home", href: "/" },
@@ -10,14 +13,12 @@ const links = [
   { name: "Contact", href: "/contact" },
 ]
 
-const settings = getSettings()
-
-export function Navbar() {
+export function Navbar({ siteName }: NavbarProps) {
   return (
     <nav className="border-b bg-background">
       <div className="container flex items-center gap-4 py-4">
         <Link href="/" className="font-bold">
-          {settings.siteName}
+          {siteName}
         </Link>
         <div className="ml-auto flex flex-wrap gap-4 text-sm">
           {links.map((link) => (

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -12,11 +12,28 @@ export interface Settings {
 }
 
 import config from "@/settings.json";
+import { fetchNostrProfile } from "./nostr";
 
 export function getSettings(): Settings {
   const site = (config as any).site as Settings;
-  const npub = (config as any).nostr.ownerNpub as string;
-  return { ...site, siteName: npub };
+  return site;
+}
+
+export async function getSiteName(): Promise<string> {
+  const site = (config as any).site as Settings;
+  const npub = (config as any).nostr?.ownerNpub as string | undefined;
+  if (!npub) return site.siteName;
+
+  try {
+    const profile = await fetchNostrProfile(npub);
+    const name =
+      profile?.display_name ||
+      profile?.name ||
+      profile?.nip05?.split("@")[0];
+    return name || site.siteName;
+  } catch {
+    return site.siteName;
+  }
 }
 
 // Placeholder to keep API compatibility

--- a/settings.json
+++ b/settings.json
@@ -2,7 +2,7 @@
   "site": {
     "showResume": true,
     "showLifestyle": true,
-    "siteName": "npub1m9vsm9d8sy0pevcjhenwm4ny6l37dm2hsg4dnusna43ql3n5305qy4zlg4",
+    "siteName": "John Doe",
     "siteDescription": "A personal blog powered by Nostr",
     "contactEmail": "",
     "socialLinks": {


### PR DESCRIPTION
## Summary
- fetch the display name from the owner's Nostr profile
- pass the fetched name to the Navbar and Footer
- generate dynamic metadata using the Nostr profile

## Testing
- `pnpm install`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_688a934c0eb08326a04bd3022cfec7c8