### PR TITLE
Fix mobile menu and layout

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -16,7 +16,7 @@ const links = [
 export function Navbar({ siteName }: NavbarProps) {
   return (
     <nav className="border-b bg-background">
-      <div className="container flex items-center gap-4 py-4">
+      <div className="container px-4 flex items-center gap-4 py-4">
         <Link href="/" className="font-bold">
           {siteName}
         </Link>

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -42,7 +42,7 @@ export function Navigation() {
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container flex h-14 items-center">
+      <div className="container px-4 flex h-14 items-center">
         <div className="mr-4 hidden md:flex">
           <Link href="/" className="mr-6 flex items-center space-x-2">
             <span className="hidden font-bold sm:inline-block">{firstName}</span>
@@ -63,12 +63,13 @@ export function Navigation() {
           </nav>
         </div>
         <Sheet open={isOpen} onOpenChange={setIsOpen}>
-          <SheetTrigger asChild>
+        <SheetTrigger asChild>
             <Button
               variant="ghost"
-              className="mr-2 px-0 text-base hover:bg-transparent focus-visible:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 md:hidden"
+              size="icon"
+              className="mr-2 h-12 w-12 hover:bg-transparent focus-visible:bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 md:hidden"
             >
-              <Menu className="h-5 w-5" />
+              <Menu className="h-6 w-6" />
               <span className="sr-only">Toggle Menu</span>
             </Button>
           </SheetTrigger>
@@ -77,14 +78,14 @@ export function Navigation() {
               <span className="font-bold">{firstName}</span>
             </Link>
             <div className="my-4 h-[calc(100vh-8rem)] pb-10 pl-6">
-              <div className="flex flex-col space-y-3">
+              <div className="flex flex-col space-y-2">
                 {navigation.map((item) => (
                   <Link
                     key={item.name}
                     href={item.href}
                     onClick={() => setIsOpen(false)}
                     className={cn(
-                      "flex items-center space-x-2 text-sm font-medium transition-colors hover:text-foreground/80",
+                      "flex items-center space-x-2 text-base font-medium transition-colors hover:text-foreground/80 h-11 px-2",
                       pathname === item.href ? "text-foreground" : "text-foreground/60",
                     )}
                   >

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -38,9 +38,9 @@ const sheetVariants = cva(
         top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
           "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        left: "inset-y-0 left-0 h-full w-full border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-full border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
     },
     defaultVariants: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,7 +13,7 @@ const config = {
   theme: {
     container: {
       center: true,
-      padding: "2rem",
+      padding: "0",
       screens: {
         "2xl": "1400px",
       },


### PR DESCRIPTION
## Summary
- remove container's default padding to free up space
- expand mobile drawer width to use full screen
- enlarge hamburger menu button and menu links for easier tapping
- add padding around navbar container for consistency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a98c6d0788326b7ed39fd96aa0c0b