### PR TITLE
feat: improve mobile layout and add menu

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -49,7 +49,7 @@ export default async function RootLayout({
   const siteName = await getSiteName()
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body className={`${inter.className} w-full`}>
         <Navbar siteName={siteName} />
         {children}
       </body>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,4 +1,8 @@
+"use client"
+
+import { useState } from "react"
 import Link from "next/link"
+import { Menu, X } from "lucide-react"
 
 interface NavbarProps {
   siteName: string
@@ -14,13 +18,15 @@ const links = [
 ]
 
 export function Navbar({ siteName }: NavbarProps) {
+  const [open, setOpen] = useState(false)
+
   return (
     <nav className="border-b bg-background">
       <div className="container flex items-center gap-4 py-4">
         <Link href="/" className="font-bold">
           {siteName}
         </Link>
-        <div className="ml-auto flex flex-wrap gap-4 text-sm">
+        <div className="ml-auto hidden flex-wrap gap-4 text-sm md:flex">
           {links.map((link) => (
             <Link
               key={link.href}
@@ -31,7 +37,37 @@ export function Navbar({ siteName }: NavbarProps) {
             </Link>
           ))}
         </div>
+        <button
+          className="ml-auto md:hidden"
+          onClick={() => setOpen(true)}
+          aria-label="Open menu"
+        >
+          <Menu className="h-6 w-6" />
+        </button>
       </div>
+      {open && (
+        <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-background">
+          <button
+            className="absolute right-4 top-4"
+            onClick={() => setOpen(false)}
+            aria-label="Close menu"
+          >
+            <X className="h-6 w-6" />
+          </button>
+          <div className="flex flex-col items-center gap-8 text-lg">
+            {links.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setOpen(false)}
+                className="hover:text-primary"
+              >
+                {link.name}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
     </nav>
   )
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,7 +13,7 @@ const config = {
   theme: {
     container: {
       center: true,
-      padding: "2rem",
+      padding: "0",
       screens: {
         "2xl": "1400px",
       },


### PR DESCRIPTION
## Summary
- remove default container padding to allow full-width mobile layout
- add responsive top-right hamburger menu with fullscreen overlay navigation
- ensure body spans full width on all devices

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688aa938ca8c83268aa8516a5c0f4980