### PR TITLE
Add mobile menu and layout fix

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -49,7 +49,7 @@ export default async function RootLayout({
   const siteName = await getSiteName()
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body className={`${inter.className} min-h-screen w-screen overflow-x-hidden`}>
         <Navbar siteName={siteName} />
         {children}
       </body>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react"
 import Link from "next/link"
+import { Menu, X } from "lucide-react"
 
 interface NavbarProps {
   siteName: string
@@ -14,13 +16,15 @@ const links = [
 ]
 
 export function Navbar({ siteName }: NavbarProps) {
+  const [open, setOpen] = useState(false)
+
   return (
     <nav className="border-b bg-background">
       <div className="container flex items-center gap-4 py-4">
         <Link href="/" className="font-bold">
           {siteName}
         </Link>
-        <div className="ml-auto flex flex-wrap gap-4 text-sm">
+        <div className="ml-auto hidden flex-wrap gap-4 text-sm md:flex">
           {links.map((link) => (
             <Link
               key={link.href}
@@ -31,7 +35,36 @@ export function Navbar({ siteName }: NavbarProps) {
             </Link>
           ))}
         </div>
+        <button
+          className="ml-auto md:hidden"
+          aria-label="Toggle Menu"
+          onClick={() => setOpen(true)}
+        >
+          <Menu className="h-6 w-6" />
+        </button>
       </div>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-8 bg-background">
+          <button
+            className="absolute right-4 top-4"
+            aria-label="Close Menu"
+            onClick={() => setOpen(false)}
+          >
+            <X className="h-6 w-6" />
+          </button>
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="text-xl font-medium text-foreground"
+              onClick={() => setOpen(false)}
+            >
+              {link.name}
+            </Link>
+          ))}
+        </div>
+      )}
     </nav>
   )
 }


### PR DESCRIPTION
## Summary
- ensure the root layout fills the full viewport width
- add a responsive hamburger menu that shows a full-screen navigation overlay

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688aa938ca8c83268aa8516a5c0f4980