### PR TITLE
Add Google Analytics tag to global layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react"
 import type { Metadata, Viewport } from "next"
 import { Inter } from "next/font/google"
+import Script from "next/script"
 import "./globals.css"
 // import { ThemeProvider } from "@/components/theme-provider"
 // import { Navigation } from "@/components/navigation"
@@ -52,6 +53,19 @@ export default async function RootLayout({
       <body className={`${inter.className} w-full`}>
         <Navbar siteName={siteName} />
         {children}
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-G8586BX397"
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'G-G8586BX397');
+          `}
+        </Script>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- load Google Analytics script on every page using `next/script`

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688ad7173ea48326aaaac7d7cedc79e2