### PR TITLE
Improve responsive layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -64,7 +64,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-x-hidden;
   }
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -132,7 +132,7 @@ export default function HomePage() {
           <Card className="mb-8 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
             <CardContent className="p-8">
               <div className="flex flex-col md:flex-row items-center md:items-center gap-8">
-                <Skeleton className="h-48 w-48 rounded-full" />
+                <Skeleton className="w-32 h-32 md:w-48 md:h-48 rounded-full" />
                 <div className="flex-1 space-y-4 text-center md:text-left">
                   <Skeleton className="h-8 w-48 mx-auto md:mx-0" />
                   <Skeleton className="h-4 w-full max-w-md mx-auto md:mx-0" />
@@ -196,7 +196,7 @@ export default function HomePage() {
           <Card className="mb-8 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm hover:shadow-xl transition-all duration-300">
             <CardContent className="p-8">
               <div className="flex flex-col md:flex-row items-center md:items-center gap-8">
-                <Avatar className="h-48 w-48 border-4 border-white dark:border-slate-700 shadow-lg">
+                <Avatar className="w-32 h-32 md:w-48 md:h-48 border-4 border-white dark:border-slate-700 shadow-lg">
                   <AvatarImage
                     src={profile.picture || "/placeholder.svg"}
                     alt={profile.name || profile.display_name || "Profile"}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -5,7 +5,7 @@ interface FooterProps {
 export function Footer({ siteName }: FooterProps) {
   return (
     <footer className="border-t py-6 text-center text-sm text-muted-foreground">
-      <div className="container mx-auto px-4">
+      <div className="w-full max-w-screen-md mx-auto px-4">
         <p>&copy; {new Date().getFullYear()} {siteName}. All rights reserved.</p>
         <p className="mt-1">Powered by Nostr and Next.js</p>
       </div>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -22,7 +22,7 @@ export function Navbar({ siteName }: NavbarProps) {
 
   return (
     <nav className="border-b bg-background">
-      <div className="container flex items-center gap-4 py-4">
+      <div className="w-full max-w-screen-md mx-auto px-4 flex items-center gap-4 py-4">
         <Link href="/" className="font-bold">
           {siteName}
         </Link>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,9 +13,13 @@ const config = {
   theme: {
     container: {
       center: true,
-      padding: "0",
+      padding: "1rem",
       screens: {
-        "2xl": "1400px",
+        sm: "100%",
+        md: "768px",
+        lg: "768px",
+        xl: "768px",
+        "2xl": "768px",
       },
     },
     extend: {


### PR DESCRIPTION
## Summary
- restrict Tailwind container width to `screen-md` and add default padding
- hide horizontal overflow and adjust avatar size for better mobile experience
- keep navbar and footer content within a centered responsive wrapper

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688b7fb4786083268a54226f5a65b1d0