### PR TITLE
fix long note previews breaking layout

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -104,8 +104,7 @@ export default function BlogPage() {
   }
 
   const truncateContent = (content: string, maxLength = 300) => {
-    if (content.length <= maxLength) return content
-    return content.substring(0, maxLength) + "..."
+    return content.length > maxLength ? content.slice(0, maxLength) + "\u2026" : content
   }
 
   if (loading) {
@@ -262,11 +261,11 @@ export default function BlogPage() {
                     </div>
                   </div>
                   {post.title ? (
-                    <CardTitle className="text-lg leading-tight bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
+                    <CardTitle className="break-words text-lg leading-tight bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
                       {post.title}
                     </CardTitle>
                   ) : (
-                    <CardTitle className="text-lg leading-tight bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
+                    <CardTitle className="break-words text-lg leading-tight bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
                       {truncateContent(post.content, 60)}
                     </CardTitle>
                   )}
@@ -276,8 +275,8 @@ export default function BlogPage() {
                 </CardHeader>
                 <CardContent>
                   <div className="prose prose-sm prose-slate dark:prose-invert max-w-none">
-                    <p className="text-slate-700 dark:text-slate-300 leading-relaxed">
-                      {truncateContent(post.content, 150)}
+                    <p className="break-words overflow-hidden text-slate-700 dark:text-slate-300 leading-relaxed">
+                      {truncateContent(post.content)}
                     </p>
                   </div>
                   <div className="mt-4">

--- a/app/lifestyle/page.tsx
+++ b/app/lifestyle/page.tsx
@@ -73,6 +73,10 @@ export default function LifestylePage() {
     loadPosts()
   }, [])
 
+  const truncateContent = (content: string, maxLength = 300) => {
+    return content.length > maxLength ? content.slice(0, maxLength) + "\u2026" : content
+  }
+
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-4xl font-bold mb-8 text-center">Lifestyle</h1>
@@ -105,10 +109,8 @@ export default function LifestylePage() {
                     </div>
                   </CardHeader>
                   <CardContent>
-                    <p>
-                      {post.content.length > 200
-                        ? post.content.slice(0, 200) + "..."
-                        : post.content}
+                    <p className="break-words overflow-hidden">
+                      {truncateContent(post.content)}
                     </p>
                   </CardContent>
                 </Card>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -119,9 +119,8 @@ export default function HomePage() {
     })
   }
 
-  const truncateContent = (content: string, maxLength = 200) => {
-    if (content.length <= maxLength) return content
-    return content.substring(0, maxLength) + "..."
+  const truncateContent = (content: string, maxLength = 300) => {
+    return content.length > maxLength ? content.slice(0, maxLength) + "\u2026" : content
   }
 
   if (loading) {
@@ -316,7 +315,7 @@ export default function HomePage() {
                     </div>
                   </div>
                   {post.title && (
-                    <CardTitle className="text-xl bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
+                    <CardTitle className="break-words text-xl bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
                       {post.title}
                     </CardTitle>
                   )}
@@ -328,7 +327,7 @@ export default function HomePage() {
                 </CardHeader>
                 <CardContent>
                   <div className="prose prose-slate dark:prose-invert max-w-none">
-                    <p className="text-slate-700 dark:text-slate-300 leading-relaxed">
+                    <p className="break-words overflow-hidden text-slate-700 dark:text-slate-300 leading-relaxed">
                       {truncateContent(post.content)}
                     </p>
                   </div>


### PR DESCRIPTION
## Summary
- truncate Nostr note previews to 300 characters
- ensure note titles and bodies wrap without overflowing

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688b894e16a48326a90b42ff4be7c1c1