### PR TITLE
Fix note preview overflow on small screens

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -90,7 +90,7 @@ ${formData.message}`
               <CheckCircle className="h-16 w-16 text-green-500 mx-auto mb-4" />
               <h2 className="text-2xl font-bold mb-2 text-green-600 dark:text-green-400">Message Sent!</h2>
               <p className="text-slate-600 dark:text-slate-300 mb-6">
-                Your message has been successfully sent via Nostr. I'll get back to you as soon as possible.
+                  Your message has been successfully sent via Nostr. I’ll get back to you as soon as possible.
               </p>
               <Button onClick={() => setIsSubmitted(false)} variant="outline">
                 Send Another Message
@@ -112,7 +112,7 @@ ${formData.message}`
               Contact Me
             </CardTitle>
             <CardDescription className="text-lg">
-              Send me a message via Nostr. I'll receive it as an encrypted DM and get back to you soon!
+                Send me a message via Nostr. I’ll receive it as an encrypted DM and get back to you soon!
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -119,9 +119,9 @@ export default function HomePage() {
     })
   }
 
-  const truncateContent = (content: string, maxLength = 200) => {
+  const truncateContent = (content: string, maxLength = 300) => {
     if (content.length <= maxLength) return content
-    return content.substring(0, maxLength) + "..."
+    return content.slice(0, maxLength) + "…"
   }
 
   if (loading) {
@@ -327,8 +327,8 @@ export default function HomePage() {
                   )}
                 </CardHeader>
                 <CardContent>
-                  <div className="prose prose-slate dark:prose-invert max-w-none">
-                    <p className="text-slate-700 dark:text-slate-300 leading-relaxed">
+                  <div className="prose prose-slate dark:prose-invert max-w-none w-full">
+                    <p className="text-slate-700 dark:text-slate-300 leading-relaxed break-words overflow-hidden line-clamp-3">
                       {truncateContent(post.content)}
                     </p>
                   </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4430,7 +4430,7 @@ snapshots:
       eslint: 8.0.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.0.0))(eslint@8.0.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.0.0)(typescript@5.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.0.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.0.0)(typescript@5.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.0.0))(eslint@8.0.0))(eslint@8.0.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.0.0)
       eslint-plugin-react: 7.37.5(eslint@8.0.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.0.0)
@@ -4460,7 +4460,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.0.0)(typescript@5.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.0.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.0.0)(typescript@5.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.0.0))(eslint@8.0.0))(eslint@8.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4475,7 +4475,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.0.0)(typescript@5.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.0.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.0.0)(typescript@5.0.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.0.0))(eslint@8.0.0))(eslint@8.0.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -260,7 +260,10 @@ const config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
+  plugins: [
+    require("tailwindcss-animate"),
+    require("@tailwindcss/typography"),
+  ],
 } satisfies Config
 
 export default config


### PR DESCRIPTION
## Summary
- limit homepage note preview to 300 chars and clamp long strings to three lines
- wrap overly long note content to prevent layout overflow
- escape apostrophes in contact page copy to satisfy lint rules

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688b894e16a48326a90b42ff4be7c1c1