### PR TITLE
Add Garden section and new digital garden notes

### DIFF
--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -18,12 +18,14 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
   })
   const html = marked.parse(content)
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-4">{note.title}</h1>
-      <div className="prose dark:prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: html }} />
+    <div className="container mx-auto max-w-3xl px-4 py-8">
+      <article className="prose dark:prose-invert">
+        <h1>{note.title}</h1>
+        <div dangerouslySetInnerHTML={{ __html: html }} />
+      </article>
       <div className="mt-8">
         <Link href="/digital-garden" className="text-blue-600 hover:underline">
-          ← Back to Digital Garden
+          ← Back to Garden
         </Link>
       </div>
     </div>

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -5,16 +5,19 @@ export default async function DigitalGardenPage() {
   const notes = await getAllNotes()
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="text-4xl font-bold mb-4">Digital Garden</h1>
-      <ul className="list-disc pl-5 space-y-2">
+      <h1 className="mb-8 text-center text-4xl font-bold">Garden</h1>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {notes.map((note) => (
-          <li key={note.slug}>
-            <Link href={`/digital-garden/${note.slug}`} className="text-blue-600 hover:underline">
-              {note.title}
-            </Link>
-          </li>
+          <Link
+            key={note.slug}
+            href={`/digital-garden/${note.slug}`}
+            className="rounded-lg border p-4 transition-colors hover:bg-muted"
+          >
+            <h2 className="text-xl font-semibold">{note.title}</h2>
+            <p className="mt-2 text-sm text-muted-foreground">Read more →</p>
+          </Link>
         ))}
-      </ul>
+      </div>
     </div>
   )
 }

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -14,6 +14,7 @@ const links = [
   { name: "Portfolio", href: "/portfolio" },
   { name: "Resume", href: "/resume" },
   { name: "Lifestyle", href: "/lifestyle" },
+  { name: "Garden", href: "/digital-garden" },
   { name: "Contact", href: "/contact" },
 ]
 

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { ModeToggle } from "@/components/mode-toggle"
-import { Menu, Home, FileText, User, Coffee, Mail } from "lucide-react"
+import { Menu, Home, FileText, User, Coffee, Mail, Leaf } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getSettings } from "@/lib/settings"
 import { getNostrSettings } from "@/lib/nostr-settings"
@@ -18,6 +18,7 @@ const navigation = [
   { name: "Portfolio", href: "/portfolio", icon: User },
   { name: "Resume", href: "/resume", icon: FileText },
   { name: "Lifestyle", href: "/lifestyle", icon: Coffee },
+  { name: "Garden", href: "/digital-garden", icon: Leaf },
   { name: "Contact", href: "/contact", icon: Mail },
 ]
 

--- a/digital-garden/fifth-note.md
+++ b/digital-garden/fifth-note.md
@@ -1,0 +1,5 @@
+---
+title: Fifth Note
+---
+
+Here the fifth note points to [[Third Note]] and [[Fourth Note]] forming a triangle.

--- a/digital-garden/fourth-note.md
+++ b/digital-garden/fourth-note.md
@@ -1,0 +1,5 @@
+---
+title: Fourth Note
+---
+
+The fourth note connects back to [[Third Note]] and across to [[Fifth Note]].

--- a/digital-garden/third-note.md
+++ b/digital-garden/third-note.md
@@ -1,0 +1,5 @@
+---
+title: Third Note
+---
+
+This is the third note in the garden. It links to [[Fourth Note]] and [[Fifth Note]].


### PR DESCRIPTION
## Summary
- Link a new "Garden" section from navigation
- Style digital garden listing and note pages for a richer presentation
- Add three interlinked garden notes

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688b8752e100832689f3382688b5a898