### PR TITLE
feat: enhance digital garden notes

### DIFF
--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { marked } from 'marked'
 import { getNote } from '@/lib/digital-garden'
+import { Card, CardHeader, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
 
 function slugify(text: string) {
   return text.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
@@ -19,10 +21,25 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
   const html = marked.parse(content)
   return (
     <div className="container mx-auto max-w-3xl px-4 py-8">
-      <article className="prose dark:prose-invert">
-        <h1>{note.title}</h1>
-        <div dangerouslySetInnerHTML={{ __html: html }} />
-      </article>
+      <Card>
+        <CardHeader>
+          <h1 className="text-3xl font-bold">{note.title}</h1>
+          {note.tags.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {note.tags.map((tag) => (
+                <Badge key={tag} variant="secondary">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </CardHeader>
+        <CardContent>
+          <article className="prose dark:prose-invert">
+            <div dangerouslySetInnerHTML={{ __html: html }} />
+          </article>
+        </CardContent>
+      </Card>
       <div className="mt-8">
         <Link href="/digital-garden" className="text-blue-600 hover:underline">
           ← Back to Garden

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -1,20 +1,34 @@
 import Link from 'next/link'
 import { getAllNotes } from '@/lib/digital-garden'
+import { getSiteName } from '@/lib/settings'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
 
 export default async function DigitalGardenPage() {
-  const notes = await getAllNotes()
+  const [notes, siteName] = await Promise.all([getAllNotes(), getSiteName()])
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="mb-8 text-center text-4xl font-bold">Garden</h1>
+      <h1 className="mb-8 text-center text-4xl font-bold">{siteName}&apos;s Garden</h1>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {notes.map((note) => (
-          <Link
-            key={note.slug}
-            href={`/digital-garden/${note.slug}`}
-            className="rounded-lg border p-4 transition-colors hover:bg-muted"
-          >
-            <h2 className="text-xl font-semibold">{note.title}</h2>
-            <p className="mt-2 text-sm text-muted-foreground">Read more →</p>
+          <Link key={note.slug} href={`/digital-garden/${note.slug}`} className="block h-full">
+            <Card className="h-full transition-colors hover:bg-muted">
+              <CardHeader>
+                <CardTitle>{note.title}</CardTitle>
+                {note.tags.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {note.tags.map((tag) => (
+                      <Badge key={tag} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">Read more →</p>
+              </CardContent>
+            </Card>
           </Link>
         ))}
       </div>

--- a/digital-garden/first-note.md
+++ b/digital-garden/first-note.md
@@ -1,6 +1,8 @@
 ---
 title: First Note
-tags: [test]
+tags: [test, meditation]
 ---
 
 This is my first digital garden note. See [[Second Note]].
+
+![Meditation icon](/meditation-icon.svg)

--- a/lib/digital-garden.ts
+++ b/lib/digital-garden.ts
@@ -5,6 +5,7 @@ import matter from 'gray-matter'
 export interface DigitalGardenNote {
   slug: string
   title: string
+  tags: string[]
 }
 
 const notesDir = path.join(process.cwd(), 'digital-garden')
@@ -17,17 +18,23 @@ export async function getAllNotes(): Promise<DigitalGardenNote[]> {
     const slug = file.replace(/\.md$/, '')
     const content = await fs.readFile(path.join(notesDir, file), 'utf8')
     const { data } = matter(content)
-    notes.push({ slug, title: (data as any).title || slug })
+    notes.push({ slug, title: (data as any).title || slug, tags: ((data as any).tags as string[]) || [] })
   }
   return notes
 }
 
-export async function getNote(slug: string): Promise<{ title: string; content: string } | null> {
+export async function getNote(
+  slug: string
+): Promise<{ title: string; content: string; tags: string[] } | null> {
   const filePath = path.join(notesDir, `${slug}.md`)
   try {
     const content = await fs.readFile(filePath, 'utf8')
     const { data, content: body } = matter(content)
-    return { title: (data as any).title || slug, content: body }
+    return {
+      title: (data as any).title || slug,
+      content: body,
+      tags: ((data as any).tags as string[]) || [],
+    }
   } catch {
     return null
   }

--- a/public/meditation-icon.svg
+++ b/public/meditation-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <circle cx="12" cy="5" r="3" />
+  <path d="M9 22c-1.1 0-2-.9-2-2v-2l-4-4 1.4-1.4L7 16v-3a3 3 0 0 1 3-3h4a3 3 0 0 1 3 3v3l2.6-2.4L21 14l-4 4v2c0 1.1-.9 2-2 2H9z" />
+</svg>


### PR DESCRIPTION
## Summary
- render site owner's name in garden title
- support tags on notes and display them in cards
- allow embedding images in notes and add meditation icon example

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688b913bf7248326b1ab939453e839cc