### PR TITLE
feat: enhance digital garden notes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { marked } from 'marked'
 import { getNote } from '@/lib/digital-garden'
+import { Badge } from '@/components/ui/badge'
 
 function slugify(text: string) {
   return text.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
@@ -21,6 +22,15 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
     <div className="container mx-auto max-w-3xl px-4 py-8">
       <article className="prose dark:prose-invert">
         <h1>{note.title}</h1>
+        {note.tags.length > 0 && (
+          <div className="mb-4 flex flex-wrap gap-2">
+            {note.tags.map((tag) => (
+              <Badge key={tag} variant="secondary">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        )}
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </article>
       <div className="mt-8">

--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -20,7 +20,7 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
   const html = marked.parse(content)
   return (
     <div className="container mx-auto max-w-3xl px-4 py-8">
-      <article className="prose dark:prose-invert">
+      <article className="prose dark:prose-invert [&_img]:h-auto [&_img]:w-16">
         <h1>{note.title}</h1>
         {note.tags.length > 0 && (
           <div className="mb-4 flex flex-wrap gap-2">

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -1,20 +1,43 @@
 import Link from 'next/link'
 import { getAllNotes } from '@/lib/digital-garden'
+import { getSiteName } from '@/lib/settings'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
 
 export default async function DigitalGardenPage() {
-  const notes = await getAllNotes()
+  const [notes, siteName] = await Promise.all([
+    getAllNotes(),
+    getSiteName(),
+  ])
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="mb-8 text-center text-4xl font-bold">Garden</h1>
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <h1 className="mb-8 text-center text-4xl font-bold">
+        {siteName}&apos;s Garden
+      </h1>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {notes.map((note) => (
-          <Link
-            key={note.slug}
-            href={`/digital-garden/${note.slug}`}
-            className="rounded-lg border p-4 transition-colors hover:bg-muted"
-          >
-            <h2 className="text-xl font-semibold">{note.title}</h2>
-            <p className="mt-2 text-sm text-muted-foreground">Read more →</p>
+          <Link key={note.slug} href={`/digital-garden/${note.slug}`} className="block">
+            <Card className="h-full transition-colors hover:bg-muted">
+              <CardHeader>
+                <CardTitle>{note.title}</CardTitle>
+              </CardHeader>
+              {note.tags.length > 0 && (
+                <CardContent className="pt-0">
+                  <div className="flex flex-wrap gap-2">
+                    {note.tags.map((tag) => (
+                      <Badge key={tag} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </CardContent>
+              )}
+            </Card>
           </Link>
         ))}
       </div>

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -9,19 +9,46 @@ import {
 } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 
-export default async function DigitalGardenPage() {
-  const [notes, siteName] = await Promise.all([
-    getAllNotes(),
-    getSiteName(),
-  ])
+export default async function DigitalGardenPage({
+  searchParams,
+}: {
+  searchParams: { tag?: string }
+}) {
+  const [notes, siteName] = await Promise.all([getAllNotes(), getSiteName()])
+  const allTags = Array.from(new Set(notes.flatMap((n) => n.tags))).sort()
+  const activeTag = searchParams.tag
+  const filteredNotes = activeTag
+    ? notes.filter((n) => n.tags.includes(activeTag))
+    : notes
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="mb-8 text-center text-4xl font-bold">
         {siteName}&apos;s Garden
       </h1>
+      {allTags.length > 0 && (
+        <div className="mb-8 flex flex-wrap justify-center gap-2">
+          <Link href="/digital-garden">
+            <Badge variant={activeTag ? 'outline' : 'default'}>All</Badge>
+          </Link>
+          {allTags.map((tag) => (
+            <Link
+              key={tag}
+              href={{ pathname: '/digital-garden', query: { tag } }}
+            >
+              <Badge variant={activeTag === tag ? 'default' : 'outline'}>
+                {tag}
+              </Badge>
+            </Link>
+          ))}
+        </div>
+      )}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {notes.map((note) => (
-          <Link key={note.slug} href={`/digital-garden/${note.slug}`} className="block">
+        {filteredNotes.map((note) => (
+          <Link
+            key={note.slug}
+            href={`/digital-garden/${note.slug}`}
+            className="block"
+          >
             <Card className="h-full transition-colors hover:bg-muted">
               <CardHeader>
                 <CardTitle>{note.title}</CardTitle>

--- a/digital-garden/third-note.md
+++ b/digital-garden/third-note.md
@@ -1,5 +1,8 @@
 ---
 title: Third Note
+tags: [meditation]
 ---
+
+![Meditation Icon](/meditation-icon.svg)
 
 This is the third note in the garden. It links to [[Fourth Note]] and [[Fifth Note]].

--- a/lib/digital-garden.ts
+++ b/lib/digital-garden.ts
@@ -5,6 +5,7 @@ import matter from 'gray-matter'
 export interface DigitalGardenNote {
   slug: string
   title: string
+  tags: string[]
 }
 
 const notesDir = path.join(process.cwd(), 'digital-garden')
@@ -17,17 +18,33 @@ export async function getAllNotes(): Promise<DigitalGardenNote[]> {
     const slug = file.replace(/\.md$/, '')
     const content = await fs.readFile(path.join(notesDir, file), 'utf8')
     const { data } = matter(content)
-    notes.push({ slug, title: (data as any).title || slug })
+    const title = (data as any).title || slug
+    const rawTags = (data as any).tags
+    const tags = Array.isArray(rawTags)
+      ? rawTags.map(String)
+      : rawTags
+      ? [String(rawTags)]
+      : []
+    notes.push({ slug, title, tags })
   }
   return notes
 }
 
-export async function getNote(slug: string): Promise<{ title: string; content: string } | null> {
+export async function getNote(
+  slug: string
+): Promise<{ title: string; tags: string[]; content: string } | null> {
   const filePath = path.join(notesDir, `${slug}.md`)
   try {
     const content = await fs.readFile(filePath, 'utf8')
     const { data, content: body } = matter(content)
-    return { title: (data as any).title || slug, content: body }
+    const title = (data as any).title || slug
+    const rawTags = (data as any).tags
+    const tags = Array.isArray(rawTags)
+      ? rawTags.map(String)
+      : rawTags
+      ? [String(rawTags)]
+      : []
+    return { title, tags, content: body }
   } catch {
     return null
   }

--- a/public/meditation-icon.svg
+++ b/public/meditation-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <text x="32" y="48" font-size="48" text-anchor="middle">🧘🏼‍♂️</text>
+</svg>


### PR DESCRIPTION
## Summary
- parse tags from markdown notes and expose them in pages
- render notes in responsive cards with owner name in title
- embed meditation icon SVG in notes

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688b913bf7248326b1ab939453e839cc