### PR TITLE
feat: add global search bar

### DIFF
--- a/app/api/digital-garden/route.ts
+++ b/app/api/digital-garden/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server'
 import { getAllNotes } from '@/lib/digital-garden'
 
-export async function GET() {
-  const notes = await getAllNotes()
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const includeContent = searchParams.get('content') === '1'
+  const notes = await getAllNotes(includeContent)
   return NextResponse.json(notes)
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -4,10 +4,9 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Search, FileText, MessageSquare, Calendar, RefreshCw } from "lucide-react"
+import { FileText, MessageSquare, Calendar, RefreshCw } from "lucide-react"
 import { fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
@@ -44,7 +43,6 @@ export default function BlogPage() {
   const [filteredPosts, setFilteredPosts] = useState<NostrPost[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState("")
   const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
 
   const loadPosts = async () => {
@@ -81,19 +79,8 @@ export default function BlogPage() {
       filtered = filtered.filter((post) => post.type === selectedType)
     }
 
-    // Filter by search term
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase()
-      filtered = filtered.filter(
-        (post) =>
-          post.content.toLowerCase().includes(term) ||
-          post.title?.toLowerCase().includes(term) ||
-          post.summary?.toLowerCase().includes(term),
-      )
-    }
-
     setFilteredPosts(filtered)
-  }, [posts, searchTerm, selectedType])
+  }, [posts, selectedType])
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp * 1000).toLocaleDateString("en-US", {
@@ -181,44 +168,33 @@ export default function BlogPage() {
           <p className="text-slate-600 dark:text-slate-300">All my thoughts, articles, and notes from Nostr</p>
         </div>
 
-        {/* Search and Filter */}
+        {/* Filter */}
         <Card className="mb-6 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
           <CardContent className="p-6">
-            <div className="flex flex-col md:flex-row gap-4">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                <Input
-                  placeholder="Search posts..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 border-0 bg-slate-100 dark:bg-slate-700"
-                />
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  variant={selectedType === "all" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("all")}
-                >
-                  All ({posts.length})
-                </Button>
-                <Button
-                  variant={selectedType === "note" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("note")}
-                >
-                  <MessageSquare className="h-4 w-4 mr-2" />
-                  Notes ({posts.filter((p) => p.type === "note").length})
-                </Button>
-                <Button
-                  variant={selectedType === "article" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("article")}
-                >
-                  <FileText className="h-4 w-4 mr-2" />
-                  Articles ({posts.filter((p) => p.type === "article").length})
-                </Button>
-              </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant={selectedType === "all" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("all")}
+              >
+                All ({posts.length})
+              </Button>
+              <Button
+                variant={selectedType === "note" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("note")}
+              >
+                <MessageSquare className="h-4 w-4 mr-2" />
+                Notes ({posts.filter((p) => p.type === "note").length})
+              </Button>
+              <Button
+                variant={selectedType === "article" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("article")}
+              >
+                <FileText className="h-4 w-4 mr-2" />
+                Articles ({posts.filter((p) => p.type === "article").length})
+              </Button>
             </div>
           </CardContent>
         </Card>
@@ -230,7 +206,9 @@ export default function BlogPage() {
               <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
                 <CardContent className="p-8 text-center">
                   <p className="text-slate-600 dark:text-slate-300">
-                    {posts.length === 0 ? "No posts found." : "No posts match your search criteria."}
+                    {posts.length === 0
+                      ? "No posts found."
+                      : "No posts match the selected filter."}
                   </p>
                 </CardContent>
               </Card>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,11 +4,10 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Search, FileText, MessageSquare, Calendar, ExternalLink, RefreshCw } from "lucide-react"
+import { FileText, MessageSquare, Calendar, ExternalLink, RefreshCw } from "lucide-react"
 import { fetchNostrProfile, fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
@@ -46,7 +45,6 @@ export default function HomePage() {
   const [filteredPosts, setFilteredPosts] = useState<NostrPost[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState("")
   const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
   const [notes, setNotes] = useState<{ slug: string; title: string }[]>([])
 
@@ -97,19 +95,8 @@ export default function HomePage() {
       filtered = filtered.filter((post) => post.type === selectedType)
     }
 
-    // Filter by search term
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase()
-      filtered = filtered.filter(
-        (post) =>
-          post.content.toLowerCase().includes(term) ||
-          post.title?.toLowerCase().includes(term) ||
-          post.summary?.toLowerCase().includes(term),
-      )
-    }
-
     setFilteredPosts(filtered)
-  }, [posts, searchTerm, selectedType])
+  }, [posts, selectedType])
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp * 1000).toLocaleDateString("en-US", {
@@ -236,44 +223,33 @@ export default function HomePage() {
           </Card>
         )}
 
-        {/* Search and Filter */}
+        {/* Filter */}
         <Card className="mb-6 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
           <CardContent className="p-6">
-            <div className="flex flex-col md:flex-row gap-4">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                <Input
-                  placeholder="Search posts..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 border-0 bg-slate-100 dark:bg-slate-700"
-                />
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  variant={selectedType === "all" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("all")}
-                >
-                  All
-                </Button>
-                <Button
-                  variant={selectedType === "note" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("note")}
-                >
-                  <MessageSquare className="h-4 w-4 mr-2" />
-                  Notes
-                </Button>
-                <Button
-                  variant={selectedType === "article" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("article")}
-                >
-                  <FileText className="h-4 w-4 mr-2" />
-                  Articles
-                </Button>
-              </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant={selectedType === "all" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("all")}
+              >
+                All
+              </Button>
+              <Button
+                variant={selectedType === "note" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("note")}
+              >
+                <MessageSquare className="h-4 w-4 mr-2" />
+                Notes
+              </Button>
+              <Button
+                variant={selectedType === "article" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("article")}
+              >
+                <FileText className="h-4 w-4 mr-2" />
+                Articles
+              </Button>
             </div>
           </CardContent>
         </Card>
@@ -285,7 +261,9 @@ export default function HomePage() {
             <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
               <CardContent className="p-8 text-center">
                 <p className="text-slate-600 dark:text-slate-300">
-                  {posts.length === 0 ? "No posts found." : "No posts match your search criteria."}
+                  {posts.length === 0
+                    ? "No posts found."
+                    : "No posts match the selected filter."}
                 </p>
               </CardContent>
             </Card>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { useSearchParams } from "next/navigation"
+import Link from "next/link"
+import { fetchNostrPosts } from "@/lib/nostr"
+import { getNostrSettings } from "@/lib/nostr-settings"
+
+interface NostrPost {
+  id: string
+  content: string
+  type: "note" | "article"
+  title?: string
+  summary?: string
+}
+
+interface GardenNote {
+  slug: string
+  title: string
+  content?: string
+}
+
+interface ResultItem {
+  type: string
+  title: string
+  url: string
+  snippet: string
+}
+
+export default function SearchPage() {
+  const params = useSearchParams()
+  const query = (params.get("q") || "").toLowerCase()
+  const filter = params.get("type") || "all"
+  const [posts, setPosts] = useState<NostrPost[]>([])
+  const [notes, setNotes] = useState<GardenNote[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      const settings = getNostrSettings()
+      const postsPromise = settings.ownerNpub
+        ? fetchNostrPosts(settings.ownerNpub, 100)
+        : Promise.resolve([] as NostrPost[])
+      const notesPromise = fetch("/api/digital-garden?content=1").then((res) =>
+        res.json(),
+      )
+      const [p, n] = await Promise.all([postsPromise, notesPromise])
+      setPosts(p)
+      setNotes(n)
+      setLoading(false)
+    }
+    load()
+  }, [])
+
+  const results = useMemo<ResultItem[]>(() => {
+    if (!query) return []
+    const items: ResultItem[] = []
+    if (filter === "all" || filter === "nostr" || filter === "articles") {
+      posts.forEach((post) => {
+        if (
+          (filter === "nostr" && post.type !== "note") ||
+          (filter === "articles" && post.type !== "article")
+        )
+          return
+        const haystack = (
+          post.content +
+          " " +
+          (post.title || "") +
+          " " +
+          (post.summary || "")
+        ).toLowerCase()
+        if (haystack.includes(query)) {
+          items.push({
+            type: post.type === "note" ? "Nostr" : "Article",
+            title: post.title || post.content.slice(0, 80),
+            url: `/blog/${post.id}`,
+            snippet: post.summary || post.content.slice(0, 120),
+          })
+        }
+      })
+    }
+    if (filter === "all" || filter === "garden") {
+      notes.forEach((note) => {
+        const haystack = (
+          note.title + " " + (note.content || "")
+        ).toLowerCase()
+        if (haystack.includes(query)) {
+          items.push({
+            type: "Garden",
+            title: note.title,
+            url: `/digital-garden/${note.slug}`,
+            snippet: note.content?.slice(0, 120) || "",
+          })
+        }
+      })
+    }
+    return items
+  }, [query, filter, posts, notes])
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold">Search Results</h1>
+      {loading ? (
+        <p>Loading...</p>
+      ) : !query ? (
+        <p>Enter a search term above.</p>
+      ) : results.length === 0 ? (
+        <p>No results found.</p>
+      ) : (
+        <div className="space-y-4">
+          {results.map((r, i) => (
+            <div key={i} className="rounded-lg border p-4">
+              <div className="text-sm text-muted-foreground mb-1">{r.type}</div>
+              <Link href={r.url} className="text-lg font-semibold hover:underline">
+                {r.title}
+              </Link>
+              <p className="text-sm text-muted-foreground mt-1">{r.snippet}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -2,11 +2,19 @@
 
 import { useState, useEffect } from "react"
 import Link from "next/link"
-import { usePathname } from "next/navigation"
+import { usePathname, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { ModeToggle } from "@/components/mode-toggle"
-import { Menu, Home, FileText, User, Coffee, Mail, Leaf } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Menu, Home, FileText, User, Coffee, Mail, Leaf, Search } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getSettings } from "@/lib/settings"
 import { getNostrSettings } from "@/lib/nostr-settings"
@@ -26,6 +34,9 @@ export function Navigation() {
   const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
   const [firstName, setFirstName] = useState(() => getSettings().siteName)
+  const [searchQuery, setSearchQuery] = useState("")
+  const [searchType, setSearchType] = useState("all")
+  const router = useRouter()
 
   useEffect(() => {
     const settings = getNostrSettings()
@@ -40,6 +51,13 @@ export function Navigation() {
       }
     })
   }, [])
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!searchQuery.trim()) return
+    router.push(`/search?q=${encodeURIComponent(searchQuery)}&type=${searchType}`)
+    setSearchQuery("")
+  }
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -104,6 +122,29 @@ export function Navigation() {
               <span className="font-bold">{firstName}</span>
             </Link>
           </div>
+          <form onSubmit={handleSearch} className="flex flex-1 items-center gap-2">
+            <Select value={searchType} onValueChange={setSearchType}>
+              <SelectTrigger className="w-[110px]">
+                <SelectValue placeholder="All" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All</SelectItem>
+                <SelectItem value="nostr">Nostr</SelectItem>
+                <SelectItem value="articles">Articles</SelectItem>
+                <SelectItem value="garden">Garden</SelectItem>
+              </SelectContent>
+            </Select>
+            <div className="relative flex-1">
+              <Search className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                type="search"
+                placeholder="Search..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-8"
+              />
+            </div>
+          </form>
           <nav className="flex items-center space-x-2">
             <ModeToggle />
           </nav>

--- a/lib/digital-garden.ts
+++ b/lib/digital-garden.ts
@@ -5,19 +5,24 @@ import matter from 'gray-matter'
 export interface DigitalGardenNote {
   slug: string
   title: string
+  content?: string
 }
 
 const notesDir = path.join(process.cwd(), 'digital-garden')
 
-export async function getAllNotes(): Promise<DigitalGardenNote[]> {
+export async function getAllNotes(includeContent = false): Promise<DigitalGardenNote[]> {
   const files = await fs.readdir(notesDir)
   const notes: DigitalGardenNote[] = []
   for (const file of files) {
     if (!file.endsWith('.md')) continue
     const slug = file.replace(/\.md$/, '')
-    const content = await fs.readFile(path.join(notesDir, file), 'utf8')
-    const { data } = matter(content)
-    notes.push({ slug, title: (data as any).title || slug })
+    const raw = await fs.readFile(path.join(notesDir, file), 'utf8')
+    const { data, content } = matter(raw)
+    notes.push({
+      slug,
+      title: (data as any).title || slug,
+      ...(includeContent ? { content } : {}),
+    })
   }
   return notes
 }


### PR DESCRIPTION
## Summary
- move search bar into navbar with content filter options
- add `/search` page to query Nostr posts, articles, and garden notes
- expose digital garden note content via API to power search

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688b920b1b8883268b6c4782bdd0e0f4