### PR TITLE
Add global search bar with category filters

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -4,10 +4,9 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Search, FileText, MessageSquare, Calendar, RefreshCw } from "lucide-react"
+import { FileText, MessageSquare, Calendar, RefreshCw } from "lucide-react"
 import { fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
@@ -41,11 +40,8 @@ interface NostrPost {
 
 export default function BlogPage() {
   const [posts, setPosts] = useState<NostrPost[]>([])
-  const [filteredPosts, setFilteredPosts] = useState<NostrPost[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState("")
-  const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
 
   const loadPosts = async () => {
     try {
@@ -60,7 +56,6 @@ export default function BlogPage() {
 
       const postsData = await fetchNostrPosts(settings.ownerNpub, 100)
       setPosts(postsData)
-      setFilteredPosts(postsData)
     } catch (err) {
       console.error("Error loading posts:", err)
       setError("Failed to load posts. Please try again.")
@@ -72,28 +67,6 @@ export default function BlogPage() {
   useEffect(() => {
     loadPosts()
   }, [])
-
-  useEffect(() => {
-    let filtered = posts
-
-    // Filter by type
-    if (selectedType !== "all") {
-      filtered = filtered.filter((post) => post.type === selectedType)
-    }
-
-    // Filter by search term
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase()
-      filtered = filtered.filter(
-        (post) =>
-          post.content.toLowerCase().includes(term) ||
-          post.title?.toLowerCase().includes(term) ||
-          post.summary?.toLowerCase().includes(term),
-      )
-    }
-
-    setFilteredPosts(filtered)
-  }, [posts, searchTerm, selectedType])
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp * 1000).toLocaleDateString("en-US", {
@@ -181,62 +154,18 @@ export default function BlogPage() {
           <p className="text-slate-600 dark:text-slate-300">All my thoughts, articles, and notes from Nostr</p>
         </div>
 
-        {/* Search and Filter */}
-        <Card className="mb-6 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
-          <CardContent className="p-6">
-            <div className="flex flex-col md:flex-row gap-4">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                <Input
-                  placeholder="Search posts..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 border-0 bg-slate-100 dark:bg-slate-700"
-                />
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  variant={selectedType === "all" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("all")}
-                >
-                  All ({posts.length})
-                </Button>
-                <Button
-                  variant={selectedType === "note" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("note")}
-                >
-                  <MessageSquare className="h-4 w-4 mr-2" />
-                  Notes ({posts.filter((p) => p.type === "note").length})
-                </Button>
-                <Button
-                  variant={selectedType === "article" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("article")}
-                >
-                  <FileText className="h-4 w-4 mr-2" />
-                  Articles ({posts.filter((p) => p.type === "article").length})
-                </Button>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
         {/* Posts Grid */}
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {filteredPosts.length === 0 ? (
+          {posts.length === 0 ? (
             <div className="col-span-full">
               <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
                 <CardContent className="p-8 text-center">
-                  <p className="text-slate-600 dark:text-slate-300">
-                    {posts.length === 0 ? "No posts found." : "No posts match your search criteria."}
-                  </p>
+                  <p className="text-slate-600 dark:text-slate-300">No posts found.</p>
                 </CardContent>
               </Card>
             </div>
           ) : (
-            filteredPosts.map((post) => (
+            posts.map((post) => (
               <Card
                 key={post.id}
                 className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,11 +4,10 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Search, FileText, MessageSquare, Calendar, ExternalLink, RefreshCw } from "lucide-react"
+import { FileText, MessageSquare, Calendar, ExternalLink, RefreshCw } from "lucide-react"
 import { fetchNostrProfile, fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
@@ -43,11 +42,8 @@ interface NostrPost {
 export default function HomePage() {
   const [profile, setProfile] = useState<NostrProfile | null>(null)
   const [posts, setPosts] = useState<NostrPost[]>([])
-  const [filteredPosts, setFilteredPosts] = useState<NostrPost[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState("")
-  const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
   const [notes, setNotes] = useState<{ slug: string; title: string }[]>([])
 
   const loadData = async () => {
@@ -69,7 +65,6 @@ export default function HomePage() {
 
       setProfile(profileData)
       setPosts(postsData)
-      setFilteredPosts(postsData)
     } catch (err) {
       console.error("Error loading data:", err)
       setError("Failed to load data. Please try again.")
@@ -89,27 +84,6 @@ export default function HomePage() {
       .catch((err) => console.error('Failed to load notes', err))
   }, [])
 
-  useEffect(() => {
-    let filtered = posts
-
-    // Filter by type
-    if (selectedType !== "all") {
-      filtered = filtered.filter((post) => post.type === selectedType)
-    }
-
-    // Filter by search term
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase()
-      filtered = filtered.filter(
-        (post) =>
-          post.content.toLowerCase().includes(term) ||
-          post.title?.toLowerCase().includes(term) ||
-          post.summary?.toLowerCase().includes(term),
-      )
-    }
-
-    setFilteredPosts(filtered)
-  }, [posts, searchTerm, selectedType])
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp * 1000).toLocaleDateString("en-US", {
@@ -236,61 +210,17 @@ export default function HomePage() {
           </Card>
         )}
 
-        {/* Search and Filter */}
-        <Card className="mb-6 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
-          <CardContent className="p-6">
-            <div className="flex flex-col md:flex-row gap-4">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                <Input
-                  placeholder="Search posts..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 border-0 bg-slate-100 dark:bg-slate-700"
-                />
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  variant={selectedType === "all" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("all")}
-                >
-                  All
-                </Button>
-                <Button
-                  variant={selectedType === "note" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("note")}
-                >
-                  <MessageSquare className="h-4 w-4 mr-2" />
-                  Notes
-                </Button>
-                <Button
-                  variant={selectedType === "article" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("article")}
-                >
-                  <FileText className="h-4 w-4 mr-2" />
-                  Articles
-                </Button>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
         {/* Posts */}
         <h2 className="text-2xl font-bold mb-4">Latest Posts</h2>
         <div className="space-y-6">
-          {filteredPosts.length === 0 ? (
+          {posts.length === 0 ? (
             <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
               <CardContent className="p-8 text-center">
-                <p className="text-slate-600 dark:text-slate-300">
-                  {posts.length === 0 ? "No posts found." : "No posts match your search criteria."}
-                </p>
+                <p className="text-slate-600 dark:text-slate-300">No posts found.</p>
               </CardContent>
             </Card>
           ) : (
-            filteredPosts.map((post) => (
+            posts.map((post) => (
               <Card
                 key={post.id}
                 className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300"

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import Link from "next/link"
 import { Menu, X } from "lucide-react"
+import SearchBar from "./search-bar"
 
 interface NavbarProps {
   siteName: string
@@ -27,6 +28,7 @@ export function Navbar({ siteName }: NavbarProps) {
         <Link href="/" className="font-bold">
           {siteName}
         </Link>
+        <SearchBar />
         <div className="ml-auto hidden flex-wrap gap-4 text-sm md:flex">
           {links.map((link) => (
             <Link

--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import { useState, useEffect, useMemo } from "react"
+import Link from "next/link"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
+import { fetchNostrPosts } from "@/lib/nostr"
+import { getNostrSettings } from "@/lib/nostr-settings"
+import { Search as SearchIcon, MessageSquare, FileText, BookOpen } from "lucide-react"
+
+interface SearchItem {
+  type: "nostr" | "article" | "garden"
+  title: string
+  url: string
+  content?: string
+}
+
+export function SearchBar() {
+  const [query, setQuery] = useState("")
+  const [filter, setFilter] = useState<string>("all")
+  const [items, setItems] = useState<SearchItem[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const settings = getNostrSettings()
+        const posts = await fetchNostrPosts(settings.ownerNpub, settings.maxPosts)
+        const notesRes = await fetch("/api/digital-garden")
+        const notes = await notesRes.json()
+        const allItems: SearchItem[] = [
+          ...posts.map((post) => ({
+            type: post.type === "article" ? "article" : "nostr",
+            title: post.title || post.content.slice(0, 50),
+            url: `/blog/${post.id}`,
+            content: post.content,
+          })),
+          ...notes.map((n: any) => ({
+            type: "garden",
+            title: n.title,
+            url: `/digital-garden/${n.slug}`,
+          })),
+        ]
+        setItems(allItems)
+      } catch (err) {
+        console.error("Failed to load search data", err)
+      }
+    }
+    load()
+  }, [])
+
+  const results = useMemo(() => {
+    if (!query) return []
+    const term = query.toLowerCase()
+    return items.filter((item) => {
+      if (filter !== "all" && item.type !== filter) return false
+      return (
+        item.title.toLowerCase().includes(term) ||
+        (item.content && item.content.toLowerCase().includes(term))
+      )
+    })
+  }, [query, filter, items])
+
+  return (
+    <div className="relative">
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <SearchIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="pl-9 w-64"
+          />
+        </div>
+        <Select value={filter} onValueChange={setFilter}>
+          <SelectTrigger className="w-[110px]">
+            <SelectValue placeholder="All" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="nostr">Nostr</SelectItem>
+            <SelectItem value="article">Articles</SelectItem>
+            <SelectItem value="garden">Garden</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      {query && (
+        <div className="absolute z-50 mt-2 w-full rounded-md border bg-background shadow">
+          {results.length === 0 && (
+            <div className="px-4 py-2 text-sm text-muted-foreground">No results found.</div>
+          )}
+          {results.map((item) => (
+            <Link
+              key={item.url}
+              href={item.url}
+              className="flex items-center gap-2 px-4 py-2 text-sm hover:bg-accent"
+            >
+              {item.type === "nostr" && <MessageSquare className="h-4 w-4" />}
+              {item.type === "article" && <FileText className="h-4 w-4" />}
+              {item.type === "garden" && <BookOpen className="h-4 w-4" />}
+              <span className="truncate">{item.title}</span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default SearchBar


### PR DESCRIPTION
## Summary
- add SearchBar component that fetches Nostr posts and garden notes with category filtering
- embed SearchBar into Navbar for site-wide search
- remove page-level search panels from home and blog pages

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688b920b1b8883268b6c4782bdd0e0f4