### PR TITLE
feat: add global search bar and site-wide search

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,11 +4,10 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Search, FileText, MessageSquare, Calendar, ExternalLink, RefreshCw } from "lucide-react"
+import { FileText, MessageSquare, Calendar, ExternalLink, RefreshCw } from "lucide-react"
 import { fetchNostrProfile, fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
@@ -235,48 +234,6 @@ export default function HomePage() {
             </CardContent>
           </Card>
         )}
-
-        {/* Search and Filter */}
-        <Card className="mb-6 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
-          <CardContent className="p-6">
-            <div className="flex flex-col md:flex-row gap-4">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                <Input
-                  placeholder="Search posts..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 border-0 bg-slate-100 dark:bg-slate-700"
-                />
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  variant={selectedType === "all" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("all")}
-                >
-                  All
-                </Button>
-                <Button
-                  variant={selectedType === "note" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("note")}
-                >
-                  <MessageSquare className="h-4 w-4 mr-2" />
-                  Notes
-                </Button>
-                <Button
-                  variant={selectedType === "article" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("article")}
-                >
-                  <FileText className="h-4 w-4 mr-2" />
-                  Articles
-                </Button>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
 
         {/* Posts */}
         <h2 className="text-2xl font-bold mb-4">Latest Posts</h2>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+import { searchContent, SearchSource } from '@/lib/search'
+
+export default async function SearchPage({
+  searchParams,
+}: {
+  searchParams: { q?: string; source?: SearchSource }
+}) {
+  const query = searchParams.q ?? ''
+  const source = (searchParams.source as SearchSource) ?? 'all'
+  const results = await searchContent(query, source)
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold">Search Results</h1>
+      {results.length === 0 ? (
+        <p>No results found.</p>
+      ) : (
+        <ul className="space-y-4">
+          {results.map((res, idx) => (
+            <li key={idx} className="rounded border p-4">
+              <div className="mb-1 text-sm capitalize text-muted-foreground">{res.type}</div>
+              <Link href={res.url} className="font-semibold hover:underline">
+                {res.title}
+              </Link>
+              <p className="text-sm text-muted-foreground">{res.snippet}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import Link from "next/link"
 import { Menu, X } from "lucide-react"
+import { SearchBar } from "@/components/search-bar"
 
 interface NavbarProps {
   siteName: string
@@ -27,7 +28,7 @@ export function Navbar({ siteName }: NavbarProps) {
         <Link href="/" className="font-bold">
           {siteName}
         </Link>
-        <div className="ml-auto hidden flex-wrap gap-4 text-sm md:flex">
+        <div className="ml-auto hidden items-center gap-4 text-sm md:flex">
           {links.map((link) => (
             <Link
               key={link.href}
@@ -37,6 +38,7 @@ export function Navbar({ siteName }: NavbarProps) {
               {link.name}
             </Link>
           ))}
+          <SearchBar />
         </div>
         <button
           className="ml-auto md:hidden"
@@ -56,6 +58,7 @@ export function Navbar({ siteName }: NavbarProps) {
             <X className="h-6 w-6" />
           </button>
           <div className="flex flex-col items-center gap-8 text-lg">
+            <SearchBar />
             {links.map((link) => (
               <Link
                 key={link.href}

--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Search } from "lucide-react"
+
+export function SearchBar() {
+  const [term, setTerm] = useState("")
+  const [source, setSource] = useState("all")
+  const router = useRouter()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const params = new URLSearchParams()
+    if (term) params.set("q", term)
+    if (source) params.set("source", source)
+    router.push(`/search?${params.toString()}`)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-center gap-2">
+      <div className="relative">
+        <Search className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={term}
+          onChange={(e) => setTerm(e.target.value)}
+          placeholder="Search..."
+          className="pl-8 w-40 md:w-64"
+        />
+      </div>
+      <Select value={source} onValueChange={setSource}>
+        <SelectTrigger className="w-[110px]">
+          <SelectValue placeholder="All" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All</SelectItem>
+          <SelectItem value="nostr">Nostr</SelectItem>
+          <SelectItem value="article">Articles</SelectItem>
+          <SelectItem value="garden">Garden</SelectItem>
+        </SelectContent>
+      </Select>
+    </form>
+  )
+}
+
+export default SearchBar
+

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,73 @@
+import fs from 'fs/promises'
+import path from 'path'
+import matter from 'gray-matter'
+import { fetchNostrPosts } from '@/lib/nostr'
+import { getNostrSettings } from '@/lib/nostr-settings'
+
+export type SearchSource = 'all' | 'nostr' | 'article' | 'garden'
+
+export interface SearchResult {
+  type: SearchSource
+  title: string
+  url: string
+  snippet: string
+}
+
+export async function searchContent(query: string, source: SearchSource = 'all'): Promise<SearchResult[]> {
+  const q = query.toLowerCase()
+  const results: SearchResult[] = []
+
+  const settings = getNostrSettings()
+
+  const includeNostr = source === 'all' || source === 'nostr' || source === 'article'
+  const includeGarden = source === 'all' || source === 'garden'
+
+  if (includeNostr && settings.ownerNpub) {
+    try {
+      const posts = await fetchNostrPosts(settings.ownerNpub, settings.maxPosts)
+      for (const post of posts) {
+        const postType: SearchSource = post.type === 'article' ? 'article' : 'nostr'
+        if (source !== 'all' && source !== postType) continue
+        const text = `${post.title ?? ''} ${post.summary ?? ''} ${post.content}`.toLowerCase()
+        if (!q || text.includes(q)) {
+          results.push({
+            type: postType,
+            title: post.title || (post.content.length > 60 ? post.content.slice(0, 60) + '…' : post.content),
+            url: `/blog/${post.id}`,
+            snippet: post.summary || post.content.slice(0, 200),
+          })
+        }
+      }
+    } catch (error) {
+      console.error('Failed to search Nostr posts', error)
+    }
+  }
+
+  if (includeGarden) {
+    const notesDir = path.join(process.cwd(), 'digital-garden')
+    try {
+      const files = await fs.readdir(notesDir)
+      for (const file of files) {
+        if (!file.endsWith('.md')) continue
+        const slug = file.replace(/\.md$/, '')
+        const raw = await fs.readFile(path.join(notesDir, file), 'utf8')
+        const { data, content } = matter(raw)
+        const title = (data as any).title || slug
+        const text = `${title} ${content}`.toLowerCase()
+        if (!q || text.includes(q)) {
+          results.push({
+            type: 'garden',
+            title,
+            url: `/digital-garden/${slug}`,
+            snippet: content.slice(0, 200),
+          })
+        }
+      }
+    } catch (error) {
+      console.error('Failed to search digital garden notes', error)
+    }
+  }
+
+  return results
+}
+


### PR DESCRIPTION
## Summary
- move search to navbar for desktop and mobile
- add dropdown filter and implement search across nostr posts, articles, and garden notes
- add search results page

## Testing
- `pnpm install`
- `pnpm lint` *(fails: The next packages will now be built: unrs-resolver. Do you approve? (y/N))*

------
https://chatgpt.com/codex/tasks/task_e_688b998546848326b89ca280bd2430e5