### PR TITLE
Add global search bar with filter options

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -4,10 +4,9 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Search, FileText, MessageSquare, Calendar, RefreshCw } from "lucide-react"
+import { FileText, MessageSquare, Calendar, RefreshCw } from "lucide-react"
 import { fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
@@ -44,7 +43,6 @@ export default function BlogPage() {
   const [filteredPosts, setFilteredPosts] = useState<NostrPost[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState("")
   const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
 
   const loadPosts = async () => {
@@ -81,19 +79,8 @@ export default function BlogPage() {
       filtered = filtered.filter((post) => post.type === selectedType)
     }
 
-    // Filter by search term
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase()
-      filtered = filtered.filter(
-        (post) =>
-          post.content.toLowerCase().includes(term) ||
-          post.title?.toLowerCase().includes(term) ||
-          post.summary?.toLowerCase().includes(term),
-      )
-    }
-
     setFilteredPosts(filtered)
-  }, [posts, searchTerm, selectedType])
+  }, [posts, selectedType])
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp * 1000).toLocaleDateString("en-US", {
@@ -181,44 +168,33 @@ export default function BlogPage() {
           <p className="text-slate-600 dark:text-slate-300">All my thoughts, articles, and notes from Nostr</p>
         </div>
 
-        {/* Search and Filter */}
+        {/* Filter */}
         <Card className="mb-6 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
           <CardContent className="p-6">
-            <div className="flex flex-col md:flex-row gap-4">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                <Input
-                  placeholder="Search posts..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 border-0 bg-slate-100 dark:bg-slate-700"
-                />
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  variant={selectedType === "all" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("all")}
-                >
-                  All ({posts.length})
-                </Button>
-                <Button
-                  variant={selectedType === "note" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("note")}
-                >
-                  <MessageSquare className="h-4 w-4 mr-2" />
-                  Notes ({posts.filter((p) => p.type === "note").length})
-                </Button>
-                <Button
-                  variant={selectedType === "article" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("article")}
-                >
-                  <FileText className="h-4 w-4 mr-2" />
-                  Articles ({posts.filter((p) => p.type === "article").length})
-                </Button>
-              </div>
+            <div className="flex gap-2">
+              <Button
+                variant={selectedType === "all" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("all")}
+              >
+                All ({posts.length})
+              </Button>
+              <Button
+                variant={selectedType === "note" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("note")}
+              >
+                <MessageSquare className="h-4 w-4 mr-2" />
+                Notes ({posts.filter((p) => p.type === "note").length})
+              </Button>
+              <Button
+                variant={selectedType === "article" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("article")}
+              >
+                <FileText className="h-4 w-4 mr-2" />
+                Articles ({posts.filter((p) => p.type === "article").length})
+              </Button>
             </div>
           </CardContent>
         </Card>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,11 +4,10 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Search, FileText, MessageSquare, Calendar, ExternalLink, RefreshCw } from "lucide-react"
+import { FileText, MessageSquare, Calendar, ExternalLink, RefreshCw } from "lucide-react"
 import { fetchNostrProfile, fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
@@ -46,7 +45,6 @@ export default function HomePage() {
   const [filteredPosts, setFilteredPosts] = useState<NostrPost[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState("")
   const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
   const [notes, setNotes] = useState<{ slug: string; title: string }[]>([])
 
@@ -97,19 +95,8 @@ export default function HomePage() {
       filtered = filtered.filter((post) => post.type === selectedType)
     }
 
-    // Filter by search term
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase()
-      filtered = filtered.filter(
-        (post) =>
-          post.content.toLowerCase().includes(term) ||
-          post.title?.toLowerCase().includes(term) ||
-          post.summary?.toLowerCase().includes(term),
-      )
-    }
-
     setFilteredPosts(filtered)
-  }, [posts, searchTerm, selectedType])
+  }, [posts, selectedType])
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp * 1000).toLocaleDateString("en-US", {
@@ -236,44 +223,33 @@ export default function HomePage() {
           </Card>
         )}
 
-        {/* Search and Filter */}
+        {/* Filter */}
         <Card className="mb-6 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
           <CardContent className="p-6">
-            <div className="flex flex-col md:flex-row gap-4">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                <Input
-                  placeholder="Search posts..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 border-0 bg-slate-100 dark:bg-slate-700"
-                />
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  variant={selectedType === "all" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("all")}
-                >
-                  All
-                </Button>
-                <Button
-                  variant={selectedType === "note" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("note")}
-                >
-                  <MessageSquare className="h-4 w-4 mr-2" />
-                  Notes
-                </Button>
-                <Button
-                  variant={selectedType === "article" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("article")}
-                >
-                  <FileText className="h-4 w-4 mr-2" />
-                  Articles
-                </Button>
-              </div>
+            <div className="flex gap-2">
+              <Button
+                variant={selectedType === "all" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("all")}
+              >
+                All
+              </Button>
+              <Button
+                variant={selectedType === "note" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("note")}
+              >
+                <MessageSquare className="h-4 w-4 mr-2" />
+                Notes
+              </Button>
+              <Button
+                variant={selectedType === "article" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("article")}
+              >
+                <FileText className="h-4 w-4 mr-2" />
+                Articles
+              </Button>
             </div>
           </CardContent>
         </Card>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { fetchNostrPosts } from "@/lib/nostr"
+import { getNostrSettings } from "@/lib/nostr-settings"
+import { getAllNotes, getNote } from "@/lib/digital-garden"
+
+interface SearchParams {
+  q?: string
+  source?: string
+}
+
+interface Result {
+  type: string
+  title: string
+  url: string
+  snippet: string
+}
+
+export default async function SearchPage({ searchParams }: { searchParams: SearchParams }) {
+  const query = searchParams.q?.toLowerCase() || ""
+  const source = (searchParams.source || "all").toLowerCase()
+  const results: Result[] = []
+
+  if (query) {
+    if (["all", "nostr", "articles"].includes(source)) {
+      const settings = getNostrSettings()
+      if (settings.ownerNpub) {
+        const posts = await fetchNostrPosts(settings.ownerNpub, 100)
+        for (const post of posts) {
+          if (source === "nostr" && post.type !== "note") continue
+          if (source === "articles" && post.type !== "article") continue
+          const text = (
+            post.content + " " + (post.title || "") + " " + (post.summary || "")
+          ).toLowerCase()
+          if (text.includes(query)) {
+            results.push({
+              type: post.type === "article" ? "Article" : "Nostr",
+              title: post.title || post.content.slice(0, 50),
+              url: `/blog/${post.id}`,
+              snippet: post.summary || post.content.slice(0, 100),
+            })
+          }
+        }
+      }
+    }
+
+    if (source === "all" || source === "garden") {
+      const notes = await getAllNotes()
+      for (const note of notes) {
+        const data = await getNote(note.slug)
+        const text = (note.title + " " + (data?.content || "")).toLowerCase()
+        if (text.includes(query)) {
+          results.push({
+            type: "Garden",
+            title: note.title,
+            url: `/digital-garden/${note.slug}`,
+            snippet: (data?.content || "").slice(0, 100),
+          })
+        }
+      }
+    }
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="mb-6 text-3xl font-bold">Search Results</h1>
+      {query ? (
+        results.length > 0 ? (
+          <div className="space-y-4">
+            {results.map((res, idx) => (
+              <Card key={idx}>
+                <CardHeader className="flex items-center justify-between">
+                  <CardTitle>{res.title}</CardTitle>
+                  <Badge variant="secondary">{res.type}</Badge>
+                </CardHeader>
+                <CardContent>
+                  <p className="mb-2 text-sm text-muted-foreground">{res.snippet}</p>
+                  <Link href={res.url} className="text-sm text-blue-600 hover:underline">
+                    View
+                  </Link>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <p>No results found for &quot;{query}&quot;.</p>
+        )
+      ) : (
+        <p>Enter a search term in the bar above.</p>
+      )}
+    </div>
+  )
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import Link from "next/link"
 import { Menu, X } from "lucide-react"
+import SearchBar from "@/components/search-bar"
 
 interface NavbarProps {
   siteName: string
@@ -27,6 +28,7 @@ export function Navbar({ siteName }: NavbarProps) {
         <Link href="/" className="font-bold">
           {siteName}
         </Link>
+        <SearchBar className="hidden flex-1 max-w-md sm:flex ml-4" />
         <div className="ml-auto hidden flex-wrap gap-4 text-sm md:flex">
           {links.map((link) => (
             <Link
@@ -56,6 +58,10 @@ export function Navbar({ siteName }: NavbarProps) {
             <X className="h-6 w-6" />
           </button>
           <div className="flex flex-col items-center gap-8 text-lg">
+            <SearchBar
+              className="w-3/4"
+              onSearch={() => setOpen(false)}
+            />
             {links.map((link) => (
               <Link
                 key={link.href}

--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { Search } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+
+interface SearchBarProps {
+  className?: string
+  onSearch?: () => void
+}
+
+export function SearchBar({ className, onSearch }: SearchBarProps) {
+  const [term, setTerm] = useState("")
+  const [filter, setFilter] = useState("all")
+  const router = useRouter()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const q = term.trim()
+    if (!q) return
+    router.push(`/search?q=${encodeURIComponent(q)}&source=${filter}`)
+    setTerm("")
+    onSearch?.()
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={cn("flex items-center", className)}
+    >
+      <Select value={filter} onValueChange={setFilter}>
+        <SelectTrigger className="w-24 rounded-r-none border-r-0 text-xs">
+          <SelectValue placeholder="All" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All</SelectItem>
+          <SelectItem value="nostr">Nostr</SelectItem>
+          <SelectItem value="articles">Articles</SelectItem>
+          <SelectItem value="garden">Garden</SelectItem>
+        </SelectContent>
+      </Select>
+      <div className="relative flex-1">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+        <Input
+          value={term}
+          onChange={(e) => setTerm(e.target.value)}
+          placeholder="Search..."
+          className="pl-9 rounded-l-none"
+        />
+      </div>
+    </form>
+  )
+}
+
+export default SearchBar


### PR DESCRIPTION
## Summary
- move search bar to main navbar and mobile menu
- enable dropdown filter to search across nostr events, articles, or garden notes
- create search page to index nostr posts and local markdown files

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688b998546848326b89ca280bd2430e5