### PR TITLE
feat: add global search with filters

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -4,10 +4,9 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Search, FileText, MessageSquare, Calendar, RefreshCw } from "lucide-react"
+import { FileText, MessageSquare, Calendar, RefreshCw } from "lucide-react"
 import { fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
@@ -44,7 +43,6 @@ export default function BlogPage() {
   const [filteredPosts, setFilteredPosts] = useState<NostrPost[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState("")
   const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
 
   const loadPosts = async () => {
@@ -81,19 +79,8 @@ export default function BlogPage() {
       filtered = filtered.filter((post) => post.type === selectedType)
     }
 
-    // Filter by search term
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase()
-      filtered = filtered.filter(
-        (post) =>
-          post.content.toLowerCase().includes(term) ||
-          post.title?.toLowerCase().includes(term) ||
-          post.summary?.toLowerCase().includes(term),
-      )
-    }
-
     setFilteredPosts(filtered)
-  }, [posts, searchTerm, selectedType])
+  }, [posts, selectedType])
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp * 1000).toLocaleDateString("en-US", {
@@ -181,44 +168,33 @@ export default function BlogPage() {
           <p className="text-slate-600 dark:text-slate-300">All my thoughts, articles, and notes from Nostr</p>
         </div>
 
-        {/* Search and Filter */}
+        {/* Filter */}
         <Card className="mb-6 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
           <CardContent className="p-6">
-            <div className="flex flex-col md:flex-row gap-4">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                <Input
-                  placeholder="Search posts..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 border-0 bg-slate-100 dark:bg-slate-700"
-                />
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  variant={selectedType === "all" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("all")}
-                >
-                  All ({posts.length})
-                </Button>
-                <Button
-                  variant={selectedType === "note" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("note")}
-                >
-                  <MessageSquare className="h-4 w-4 mr-2" />
-                  Notes ({posts.filter((p) => p.type === "note").length})
-                </Button>
-                <Button
-                  variant={selectedType === "article" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("article")}
-                >
-                  <FileText className="h-4 w-4 mr-2" />
-                  Articles ({posts.filter((p) => p.type === "article").length})
-                </Button>
-              </div>
+            <div className="flex gap-2">
+              <Button
+                variant={selectedType === "all" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("all")}
+              >
+                All ({posts.length})
+              </Button>
+              <Button
+                variant={selectedType === "note" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("note")}
+              >
+                <MessageSquare className="h-4 w-4 mr-2" />
+                Notes ({posts.filter((p) => p.type === "note").length})
+              </Button>
+              <Button
+                variant={selectedType === "article" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("article")}
+              >
+                <FileText className="h-4 w-4 mr-2" />
+                Articles ({posts.filter((p) => p.type === "article").length})
+              </Button>
             </div>
           </CardContent>
         </Card>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,11 +4,10 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Search, FileText, MessageSquare, Calendar, ExternalLink, RefreshCw } from "lucide-react"
+import { FileText, MessageSquare, Calendar, ExternalLink, RefreshCw } from "lucide-react"
 import { fetchNostrProfile, fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
@@ -46,7 +45,6 @@ export default function HomePage() {
   const [filteredPosts, setFilteredPosts] = useState<NostrPost[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState("")
   const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
   const [notes, setNotes] = useState<{ slug: string; title: string }[]>([])
 
@@ -97,19 +95,8 @@ export default function HomePage() {
       filtered = filtered.filter((post) => post.type === selectedType)
     }
 
-    // Filter by search term
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase()
-      filtered = filtered.filter(
-        (post) =>
-          post.content.toLowerCase().includes(term) ||
-          post.title?.toLowerCase().includes(term) ||
-          post.summary?.toLowerCase().includes(term),
-      )
-    }
-
     setFilteredPosts(filtered)
-  }, [posts, searchTerm, selectedType])
+  }, [posts, selectedType])
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp * 1000).toLocaleDateString("en-US", {
@@ -236,44 +223,33 @@ export default function HomePage() {
           </Card>
         )}
 
-        {/* Search and Filter */}
+        {/* Filter */}
         <Card className="mb-6 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
           <CardContent className="p-6">
-            <div className="flex flex-col md:flex-row gap-4">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                <Input
-                  placeholder="Search posts..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 border-0 bg-slate-100 dark:bg-slate-700"
-                />
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  variant={selectedType === "all" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("all")}
-                >
-                  All
-                </Button>
-                <Button
-                  variant={selectedType === "note" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("note")}
-                >
-                  <MessageSquare className="h-4 w-4 mr-2" />
-                  Notes
-                </Button>
-                <Button
-                  variant={selectedType === "article" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("article")}
-                >
-                  <FileText className="h-4 w-4 mr-2" />
-                  Articles
-                </Button>
-              </div>
+            <div className="flex gap-2">
+              <Button
+                variant={selectedType === "all" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("all")}
+              >
+                All
+              </Button>
+              <Button
+                variant={selectedType === "note" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("note")}
+              >
+                <MessageSquare className="h-4 w-4 mr-2" />
+                Notes
+              </Button>
+              <Button
+                variant={selectedType === "article" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSelectedType("article")}
+              >
+                <FileText className="h-4 w-4 mr-2" />
+                Articles
+              </Button>
             </div>
           </CardContent>
         </Card>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,130 @@
+import Link from "next/link"
+import { getNostrSettings } from "@/lib/nostr-settings"
+import { fetchNostrPosts, type NostrPost } from "@/lib/nostr"
+import { getAllNotes, getNote } from "@/lib/digital-garden"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+
+export default async function SearchPage({
+  searchParams,
+}: {
+  searchParams: { q?: string; source?: string }
+}) {
+  const query = (searchParams.q || "").toLowerCase()
+  const source = searchParams.source || "all"
+
+  const settings = getNostrSettings()
+  const npub = settings.ownerNpub
+
+  const shouldFetchNostr = source === "all" || source === "nostr" || source === "article"
+  const shouldFetchNotes = source === "all" || source === "garden"
+
+  let posts: NostrPost[] = []
+  if (npub && shouldFetchNostr) {
+    posts = await fetchNostrPosts(npub, settings.maxPosts || 100)
+  }
+
+  let notes: { slug: string; title: string; content: string }[] = []
+  if (shouldFetchNotes) {
+    const meta = await getAllNotes()
+    notes = await Promise.all(
+      meta.map(async (m) => {
+        const n = await getNote(m.slug)
+        return { slug: m.slug, title: n?.title || m.title, content: n?.content || "" }
+      }),
+    )
+  }
+
+  const match = (text?: string) => text?.toLowerCase().includes(query)
+
+  const nostrNotes = posts.filter(
+    (p) => p.type === "note" && (!query || match(p.content))
+  )
+  const articles = posts.filter(
+    (p) =>
+      p.type === "article" &&
+      (!query || match(p.title) || match(p.content) || match(p.summary))
+  )
+  const gardenResults = notes.filter(
+    (n) => !query || match(n.title) || match(n.content)
+  )
+
+  const truncate = (text: string, max = 160) =>
+    text.length > max ? text.slice(0, max) + "…" : text
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="mb-6 text-3xl font-bold">Search Results</h1>
+      {(source === "all" || source === "nostr") && (
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold">Nostr Notes</h2>
+          {nostrNotes.length === 0 ? (
+            <p className="text-slate-600 dark:text-slate-300">No results.</p>
+          ) : (
+            <div className="space-y-4">
+              {nostrNotes.map((post) => (
+                <Card key={post.id}>
+                  <CardHeader>
+                    <CardTitle>
+                      <Link href={`/blog/${post.id}`}>{truncate(post.content)}</Link>
+                    </CardTitle>
+                  </CardHeader>
+                </Card>
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
+      {(source === "all" || source === "article") && (
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold">Articles</h2>
+          {articles.length === 0 ? (
+            <p className="text-slate-600 dark:text-slate-300">No results.</p>
+          ) : (
+            <div className="space-y-4">
+              {articles.map((post) => (
+                <Card key={post.id}>
+                  <CardHeader>
+                    <CardTitle>
+                      <Link href={`/blog/${post.id}`}>{post.title || truncate(post.content)}</Link>
+                    </CardTitle>
+                  </CardHeader>
+                  {post.summary && (
+                    <CardContent>{post.summary}</CardContent>
+                  )}
+                </Card>
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
+      {(source === "all" || source === "garden") && (
+        <section>
+          <h2 className="mb-4 text-xl font-semibold">Garden Notes</h2>
+          {gardenResults.length === 0 ? (
+            <p className="text-slate-600 dark:text-slate-300">No results.</p>
+          ) : (
+            <div className="space-y-4">
+              {gardenResults.map((note) => (
+                <Card key={note.slug}>
+                  <CardHeader>
+                    <CardTitle>
+                      <Link href={`/digital-garden/${note.slug}`}>{note.title}</Link>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-slate-600 dark:text-slate-300">
+                      {truncate(note.content)}
+                    </p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  )
+}
+

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import Link from "next/link"
 import { Menu, X } from "lucide-react"
+import { SearchBar } from "./search-bar"
 
 interface NavbarProps {
   siteName: string
@@ -27,7 +28,7 @@ export function Navbar({ siteName }: NavbarProps) {
         <Link href="/" className="font-bold">
           {siteName}
         </Link>
-        <div className="ml-auto hidden flex-wrap gap-4 text-sm md:flex">
+        <div className="ml-auto hidden flex-1 items-center gap-4 text-sm md:flex">
           {links.map((link) => (
             <Link
               key={link.href}
@@ -37,9 +38,11 @@ export function Navbar({ siteName }: NavbarProps) {
               {link.name}
             </Link>
           ))}
+          <SearchBar className="ml-auto" />
         </div>
+        <SearchBar className="ml-auto flex-1 md:hidden" />
         <button
-          className="ml-auto md:hidden"
+          className="ml-2 md:hidden"
           onClick={() => setOpen(true)}
           aria-label="Open menu"
         >
@@ -47,7 +50,7 @@ export function Navbar({ siteName }: NavbarProps) {
         </button>
       </div>
       {open && (
-        <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-background">
+        <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-background p-4">
           <button
             className="absolute right-4 top-4"
             onClick={() => setOpen(false)}
@@ -55,6 +58,7 @@ export function Navbar({ siteName }: NavbarProps) {
           >
             <X className="h-6 w-6" />
           </button>
+          <SearchBar className="mb-8 w-full max-w-xs" />
           <div className="flex flex-col items-center gap-8 text-lg">
             {links.map((link) => (
               <Link

--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { Search } from "lucide-react"
+
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+interface SearchBarProps {
+  className?: string
+}
+
+export function SearchBar({ className }: SearchBarProps) {
+  const [query, setQuery] = useState("")
+  const [source, setSource] = useState("all")
+  const router = useRouter()
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!query.trim()) return
+    const params = new URLSearchParams({ q: query.trim(), source })
+    router.push(`/search?${params.toString()}`)
+  }
+
+  return (
+    <form onSubmit={onSubmit} className={`flex items-center gap-2 ${className ?? ""}`}>
+      <Select value={source} onValueChange={setSource}>
+        <SelectTrigger className="w-24">
+          <SelectValue placeholder="All" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All</SelectItem>
+          <SelectItem value="nostr">Nostr</SelectItem>
+          <SelectItem value="article">Articles</SelectItem>
+          <SelectItem value="garden">Garden</SelectItem>
+        </SelectContent>
+      </Select>
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+        <Input
+          className="w-40 pl-8 md:w-64"
+          placeholder="Search..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+      </div>
+    </form>
+  )
+}
+

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -13,7 +13,7 @@ const DEFAULT_RELAYS = [
 const cache = new Map<string, any>()
 const CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
 
-interface NostrProfile {
+export interface NostrProfile {
   name?: string
   display_name?: string
   about?: string
@@ -24,7 +24,7 @@ interface NostrProfile {
   website?: string
 }
 
-interface NostrPost {
+export interface NostrPost {
   id: string
   pubkey: string
   created_at: number


### PR DESCRIPTION
## Summary
- move search input into navbar and support mobile menu
- add a reusable search bar component with filter options
- implement global search page that queries nostr posts, articles, and garden notes

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688b998546848326b89ca280bd2430e5