### PR TITLE
feat: add global search with filters

### DIFF
--- a/app/api/digital-garden/route.ts
+++ b/app/api/digital-garden/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server'
 import { getAllNotes } from '@/lib/digital-garden'
 
-export async function GET() {
-  const notes = await getAllNotes()
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const includeContent = searchParams.get('content') === '1'
+  const notes = await getAllNotes(includeContent)
   return NextResponse.json(notes)
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -4,10 +4,9 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Search, FileText, MessageSquare, Calendar, RefreshCw } from "lucide-react"
+import { FileText, MessageSquare, Calendar, RefreshCw } from "lucide-react"
 import { fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
@@ -41,11 +40,8 @@ interface NostrPost {
 
 export default function BlogPage() {
   const [posts, setPosts] = useState<NostrPost[]>([])
-  const [filteredPosts, setFilteredPosts] = useState<NostrPost[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState("")
-  const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
 
   const loadPosts = async () => {
     try {
@@ -60,7 +56,6 @@ export default function BlogPage() {
 
       const postsData = await fetchNostrPosts(settings.ownerNpub, 100)
       setPosts(postsData)
-      setFilteredPosts(postsData)
     } catch (err) {
       console.error("Error loading posts:", err)
       setError("Failed to load posts. Please try again.")
@@ -72,28 +67,6 @@ export default function BlogPage() {
   useEffect(() => {
     loadPosts()
   }, [])
-
-  useEffect(() => {
-    let filtered = posts
-
-    // Filter by type
-    if (selectedType !== "all") {
-      filtered = filtered.filter((post) => post.type === selectedType)
-    }
-
-    // Filter by search term
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase()
-      filtered = filtered.filter(
-        (post) =>
-          post.content.toLowerCase().includes(term) ||
-          post.title?.toLowerCase().includes(term) ||
-          post.summary?.toLowerCase().includes(term),
-      )
-    }
-
-    setFilteredPosts(filtered)
-  }, [posts, searchTerm, selectedType])
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp * 1000).toLocaleDateString("en-US", {
@@ -181,62 +154,18 @@ export default function BlogPage() {
           <p className="text-slate-600 dark:text-slate-300">All my thoughts, articles, and notes from Nostr</p>
         </div>
 
-        {/* Search and Filter */}
-        <Card className="mb-6 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
-          <CardContent className="p-6">
-            <div className="flex flex-col md:flex-row gap-4">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                <Input
-                  placeholder="Search posts..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 border-0 bg-slate-100 dark:bg-slate-700"
-                />
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  variant={selectedType === "all" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("all")}
-                >
-                  All ({posts.length})
-                </Button>
-                <Button
-                  variant={selectedType === "note" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("note")}
-                >
-                  <MessageSquare className="h-4 w-4 mr-2" />
-                  Notes ({posts.filter((p) => p.type === "note").length})
-                </Button>
-                <Button
-                  variant={selectedType === "article" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("article")}
-                >
-                  <FileText className="h-4 w-4 mr-2" />
-                  Articles ({posts.filter((p) => p.type === "article").length})
-                </Button>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
         {/* Posts Grid */}
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {filteredPosts.length === 0 ? (
+          {posts.length === 0 ? (
             <div className="col-span-full">
               <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
                 <CardContent className="p-8 text-center">
-                  <p className="text-slate-600 dark:text-slate-300">
-                    {posts.length === 0 ? "No posts found." : "No posts match your search criteria."}
-                  </p>
+                  <p className="text-slate-600 dark:text-slate-300">No posts found.</p>
                 </CardContent>
               </Card>
             </div>
           ) : (
-            filteredPosts.map((post) => (
+            posts.map((post) => (
               <Card
                 key={post.id}
                 className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,11 +4,10 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Search, FileText, MessageSquare, Calendar, ExternalLink, RefreshCw } from "lucide-react"
+import { FileText, MessageSquare, Calendar, ExternalLink, RefreshCw } from "lucide-react"
 import { fetchNostrProfile, fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
@@ -43,11 +42,8 @@ interface NostrPost {
 export default function HomePage() {
   const [profile, setProfile] = useState<NostrProfile | null>(null)
   const [posts, setPosts] = useState<NostrPost[]>([])
-  const [filteredPosts, setFilteredPosts] = useState<NostrPost[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState("")
-  const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
   const [notes, setNotes] = useState<{ slug: string; title: string }[]>([])
 
   const loadData = async () => {
@@ -69,7 +65,6 @@ export default function HomePage() {
 
       setProfile(profileData)
       setPosts(postsData)
-      setFilteredPosts(postsData)
     } catch (err) {
       console.error("Error loading data:", err)
       setError("Failed to load data. Please try again.")
@@ -88,28 +83,6 @@ export default function HomePage() {
       .then((data) => setNotes(data))
       .catch((err) => console.error('Failed to load notes', err))
   }, [])
-
-  useEffect(() => {
-    let filtered = posts
-
-    // Filter by type
-    if (selectedType !== "all") {
-      filtered = filtered.filter((post) => post.type === selectedType)
-    }
-
-    // Filter by search term
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase()
-      filtered = filtered.filter(
-        (post) =>
-          post.content.toLowerCase().includes(term) ||
-          post.title?.toLowerCase().includes(term) ||
-          post.summary?.toLowerCase().includes(term),
-      )
-    }
-
-    setFilteredPosts(filtered)
-  }, [posts, searchTerm, selectedType])
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp * 1000).toLocaleDateString("en-US", {
@@ -236,61 +209,17 @@ export default function HomePage() {
           </Card>
         )}
 
-        {/* Search and Filter */}
-        <Card className="mb-6 border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
-          <CardContent className="p-6">
-            <div className="flex flex-col md:flex-row gap-4">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                <Input
-                  placeholder="Search posts..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 border-0 bg-slate-100 dark:bg-slate-700"
-                />
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  variant={selectedType === "all" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("all")}
-                >
-                  All
-                </Button>
-                <Button
-                  variant={selectedType === "note" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("note")}
-                >
-                  <MessageSquare className="h-4 w-4 mr-2" />
-                  Notes
-                </Button>
-                <Button
-                  variant={selectedType === "article" ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setSelectedType("article")}
-                >
-                  <FileText className="h-4 w-4 mr-2" />
-                  Articles
-                </Button>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
         {/* Posts */}
         <h2 className="text-2xl font-bold mb-4">Latest Posts</h2>
         <div className="space-y-6">
-          {filteredPosts.length === 0 ? (
+          {posts.length === 0 ? (
             <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
               <CardContent className="p-8 text-center">
-                <p className="text-slate-600 dark:text-slate-300">
-                  {posts.length === 0 ? "No posts found." : "No posts match your search criteria."}
-                </p>
+                <p className="text-slate-600 dark:text-slate-300">No posts found.</p>
               </CardContent>
             </Card>
           ) : (
-            filteredPosts.map((post) => (
+            posts.map((post) => (
               <Card
                 key={post.id}
                 className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300"

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import { useSearchParams } from "next/navigation"
+import { useEffect, useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import Link from "next/link"
+import { fetchNostrPosts } from "@/lib/nostr"
+import { getNostrSettings } from "@/lib/nostr-settings"
+import { FileText, MessageSquare, BookOpen } from "lucide-react"
+
+interface SearchResult {
+  type: "note" | "article" | "garden"
+  title: string
+  content: string
+  url: string
+}
+
+export default function SearchPage() {
+  const params = useSearchParams()
+  const query = params.get("q") || ""
+  const filter = params.get("filter") || "all"
+  const [results, setResults] = useState<SearchResult[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const load = async () => {
+      if (!query) return
+      setLoading(true)
+      const term = query.toLowerCase()
+      const items: SearchResult[] = []
+
+      if (filter === "all" || filter === "nostr" || filter === "articles") {
+        const settings = getNostrSettings()
+        if (settings.ownerNpub) {
+          const posts = await fetchNostrPosts(settings.ownerNpub, settings.maxPosts)
+          posts.forEach((post) => {
+            const matches =
+              post.content.toLowerCase().includes(term) ||
+              post.title?.toLowerCase().includes(term) ||
+              post.summary?.toLowerCase().includes(term)
+            if (!matches) return
+            if (filter === "nostr" && post.type !== "note") return
+            if (filter === "articles" && post.type !== "article") return
+            items.push({
+              type: post.type,
+              title: post.title || post.content.slice(0, 60),
+              content: post.content,
+              url: `/blog/${post.id}`,
+            })
+          })
+        }
+      }
+
+      if (filter === "all" || filter === "garden") {
+        const notes = await fetch(`/api/digital-garden?content=1`).then((res) => res.json())
+        notes.forEach((note: any) => {
+          const matches =
+            note.title.toLowerCase().includes(term) ||
+            note.content.toLowerCase().includes(term)
+          if (!matches) return
+          items.push({
+            type: "garden",
+            title: note.title,
+            content: note.content,
+            url: `/digital-garden/${note.slug}`,
+          })
+        })
+      }
+
+      setResults(items)
+      setLoading(false)
+    }
+
+    load()
+  }, [query, filter])
+
+  const truncate = (str: string, len = 200) =>
+    str.length <= len ? str : str.slice(0, len) + "…"
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="mb-6 text-3xl font-bold">Search Results for &quot;{query}&quot;</h1>
+      {loading ? (
+        <p>Loading...</p>
+      ) : results.length === 0 ? (
+        <p>No results found.</p>
+      ) : (
+        <div className="space-y-6">
+          {results.map((res, idx) => (
+            <Card key={idx} className="border-0 shadow">
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <Badge variant={res.type === "article" ? "default" : res.type === "garden" ? "outline" : "secondary"}>
+                    {res.type === "article"
+                      ? "Article"
+                      : res.type === "garden"
+                      ? "Garden"
+                      : "Note"}
+                  </Badge>
+                  {res.type === "article" && <FileText className="h-4 w-4" />}
+                  {res.type === "note" && <MessageSquare className="h-4 w-4" />}
+                  {res.type === "garden" && <BookOpen className="h-4 w-4" />}
+                </div>
+                <CardTitle>{res.title}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="mb-4 text-sm text-slate-700 dark:text-slate-300">
+                  {truncate(res.content)}
+                </p>
+                <Link href={res.url} className="text-blue-600 hover:underline">
+                  Read More
+                </Link>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -2,7 +2,16 @@
 
 import { useState } from "react"
 import Link from "next/link"
-import { Menu, X } from "lucide-react"
+import { Menu, X, Search } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
 
 interface NavbarProps {
   siteName: string
@@ -20,6 +29,16 @@ const links = [
 
 export function Navbar({ siteName }: NavbarProps) {
   const [open, setOpen] = useState(false)
+  const [searchTerm, setSearchTerm] = useState("")
+  const [filter, setFilter] = useState("all")
+  const router = useRouter()
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!searchTerm.trim()) return
+    router.push(`/search?q=${encodeURIComponent(searchTerm)}&filter=${filter}`)
+    setSearchTerm("")
+  }
 
   return (
     <nav className="border-b bg-background">
@@ -27,7 +46,7 @@ export function Navbar({ siteName }: NavbarProps) {
         <Link href="/" className="font-bold">
           {siteName}
         </Link>
-        <div className="ml-auto hidden flex-wrap gap-4 text-sm md:flex">
+        <div className="hidden flex-wrap gap-4 text-sm md:flex">
           {links.map((link) => (
             <Link
               key={link.href}
@@ -38,8 +57,31 @@ export function Navbar({ siteName }: NavbarProps) {
             </Link>
           ))}
         </div>
+        <form
+          onSubmit={handleSearch}
+          className="relative ml-auto hidden items-center md:flex"
+        >
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+          <Input
+            placeholder="Search..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="w-64 pl-8 pr-20 bg-slate-100 dark:bg-slate-700 border-0"
+          />
+          <Select value={filter} onValueChange={setFilter}>
+            <SelectTrigger className="absolute right-1 top-1/2 h-7 w-20 -translate-y-1/2 border-0 bg-transparent p-0 text-xs">
+              <SelectValue placeholder="All" />
+            </SelectTrigger>
+            <SelectContent align="end">
+              <SelectItem value="all">All</SelectItem>
+              <SelectItem value="nostr">Nostr</SelectItem>
+              <SelectItem value="articles">Articles</SelectItem>
+              <SelectItem value="garden">Garden</SelectItem>
+            </SelectContent>
+          </Select>
+        </form>
         <button
-          className="ml-auto md:hidden"
+          className="ml-2 md:hidden"
           onClick={() => setOpen(true)}
           aria-label="Open menu"
         >

--- a/lib/digital-garden.ts
+++ b/lib/digital-garden.ts
@@ -6,18 +6,21 @@ export interface DigitalGardenNote {
   slug: string
   title: string
   tags: string[]
+  content?: string
 }
 
 const notesDir = path.join(process.cwd(), 'digital-garden')
 
-export async function getAllNotes(): Promise<DigitalGardenNote[]> {
+export async function getAllNotes(
+  includeContent = false,
+): Promise<DigitalGardenNote[]> {
   const files = await fs.readdir(notesDir)
   const notes: DigitalGardenNote[] = []
   for (const file of files) {
     if (!file.endsWith('.md')) continue
     const slug = file.replace(/\.md$/, '')
-    const content = await fs.readFile(path.join(notesDir, file), 'utf8')
-    const { data } = matter(content)
+    const fileContent = await fs.readFile(path.join(notesDir, file), 'utf8')
+    const { data, content } = matter(fileContent)
     const title = (data as any).title || slug
     const rawTags = (data as any).tags
     const tags = Array.isArray(rawTags)
@@ -25,7 +28,11 @@ export async function getAllNotes(): Promise<DigitalGardenNote[]> {
       : rawTags
       ? [String(rawTags)]
       : []
-    notes.push({ slug, title, tags })
+    const note: DigitalGardenNote = { slug, title, tags }
+    if (includeContent) {
+      note.content = content
+    }
+    notes.push(note)
   }
   return notes
 }


### PR DESCRIPTION
## Summary
- move search bar to the navbar and add filter for All, Nostr, Articles, Garden
- expose digital garden content for search
- add `/search` page that aggregates results from Nostr posts and local notes

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688b998546848326b89ca280bd2430e5