### PR TITLE
Rename portfolio to projects with WeAreBitcoin showcase

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -4,52 +4,30 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Github, ExternalLink } from "lucide-react"
 
-export default function PortfolioPage() {
+export default function ProjectsPage() {
   const projects = [
     {
       id: "1",
-      title: "Decentralized Chat App",
+      title: "WeAreBitcoin.org",
       description:
-        "A real-time chat application built on a decentralized network, ensuring privacy and censorship-resistance.",
-      tags: ["Web3", "React", "Nostr", "TypeScript"],
-      github: "#",
-      live: "#",
-      image: "/placeholder.png?height=200&width=400",
-    },
-    {
-      id: "2",
-      title: "AI-Powered Content Generator",
-      description: "A tool that leverages AI models to generate creative content, from blog posts to marketing copy.",
-      tags: ["AI", "Python", "Next.js", "Machine Learning"],
-      github: "#",
-      live: "#",
-      image: "/placeholder.png?height=200&width=400",
-    },
-    {
-      id: "3",
-      title: "E-commerce Platform",
-      description:
-        "A full-stack e-commerce solution with user authentication, product management, and secure payment processing.",
-      tags: ["Next.js", "Stripe", "PostgreSQL", "Tailwind CSS"],
-      github: "#",
-      live: "#",
-      image: "/placeholder.png?height=200&width=400",
-    },
-    {
-      id: "4",
-      title: "Personal Finance Tracker",
-      description:
-        "An intuitive web application to track income, expenses, and investments, helping users manage their finances effectively.",
-      tags: ["React", "Node.js", "MongoDB", "Data Visualization"],
-      github: "#",
-      live: "#",
-      image: "/placeholder.png?height=200&width=400",
+        "Content Writer and Developer at WeAreBitcoin.org, a Bitcoin education platform focused on self-custody and sound money principles.",
+      responsibilities: [
+        "Write, translate, and localize articles on Bitcoin, Austrian economics, and self-sovereignty.",
+        "Format and publish posts using Markdown and a Next.js-based CMS.",
+        "Design and test interactive tools such as onboarding wizards and DCA calculators.",
+        "Optimize content for SEO and clarity with strategic headlines and metadata.",
+        "Collaborate on visual layouts and UX to enhance engagement and learning.",
+      ],
+      tags: ["Bitcoin", "Content", "Next.js", "Education"],
+      github: "https://github.com/we-are-bitcoin",
+      live: "https://wearebitcoin.org",
+      image: "/wab.png",
     },
   ]
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="text-4xl font-bold mb-8 text-center">My Portfolio</h1>
+      <h1 className="text-4xl font-bold mb-8 text-center">Projects</h1>
       <p className="text-xl text-muted-foreground text-center mb-12">
         A collection of my work, showcasing various technologies and problem-solving approaches.
       </p>
@@ -64,7 +42,16 @@ export default function PortfolioPage() {
                 className="w-full h-48 object-cover rounded-md mb-4"
               />
               <CardTitle className="text-2xl mb-2">{project.title}</CardTitle>
-              <CardDescription className="line-clamp-3">{project.description}</CardDescription>
+              <CardDescription className="mb-4">
+                {project.description}
+              </CardDescription>
+              {project.responsibilities && (
+                <ul className="list-disc list-inside text-sm text-muted-foreground">
+                  {project.responsibilities.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              )}
             </CardHeader>
             <CardContent>
               <div className="flex flex-wrap gap-2 mb-4">
@@ -100,10 +87,11 @@ export default function PortfolioPage() {
       {projects.length === 0 && (
         <Card className="max-w-md mx-auto mt-8">
           <CardContent className="py-8 text-center">
-            <p className="text-muted-foreground">No portfolio projects to display yet. Check back soon!</p>
+            <p className="text-muted-foreground">No projects to display yet. Check back soon!</p>
           </CardContent>
         </Card>
       )}
     </div>
   )
 }
+

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -13,7 +13,7 @@ interface NavbarProps {
 const links = [
   { name: "Home", href: "/" },
   { name: "Blog", href: "/blog" },
-  { name: "Portfolio", href: "/portfolio" },
+  { name: "Projects", href: "/projects" },
   { name: "Resume", href: "/resume" },
   { name: "Lifestyle", href: "/lifestyle" },
   { name: "Garden", href: "/digital-garden" },

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -15,7 +15,7 @@ import { fetchNostrProfile } from "@/lib/nostr"
 const navigation = [
   { name: "Home", href: "/", icon: Home },
   { name: "Blog", href: "/blog", icon: FileText },
-  { name: "Portfolio", href: "/portfolio", icon: User },
+  { name: "Projects", href: "/projects", icon: User },
   { name: "Resume", href: "/resume", icon: FileText },
   { name: "Lifestyle", href: "/lifestyle", icon: Coffee },
   { name: "Garden", href: "/digital-garden", icon: Leaf },


### PR DESCRIPTION
## Summary
- replace `/portfolio` route with new `/projects` page featuring WeAreBitcoin.org project and responsibilities
- update navigation and navbar to point to `/projects`

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688ba2c73f7c832682789cae0d0cbeca