### PR TITLE
Remove Nostr NIP-05 email badge from homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -215,11 +215,6 @@ export default function HomePage() {
                         </a>
                       </Button>
                     )}
-                    {profile.nip05 && (
-                      <Badge variant="secondary" className="px-3 py-1">
-                        ✓ {profile.nip05}
-                      </Badge>
-                    )}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- drop display of owner's NIP-05 email on the main page

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688ba3d140f883269016799eb6bff472