### PR TITLE
Refine project cards and add project article

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -3,12 +3,16 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Github, ExternalLink } from "lucide-react"
+import Image from "next/image"
+import Link from "next/link"
 
 export default function ProjectsPage() {
   const projects = [
     {
       id: "1",
       title: "WeAreBitcoin.org",
+      shortDescription:
+        "Bitcoin education platform focused on self-custody and sound money principles.",
       description:
         "Content Writer and Developer at WeAreBitcoin.org, a Bitcoin education platform focused on self-custody and sound money principles.",
       responsibilities: [
@@ -22,6 +26,7 @@ export default function ProjectsPage() {
       github: "https://github.com/we-are-bitcoin",
       live: "https://wearebitcoin.org",
       image: "/wab.png",
+      link: "/projects/wearebitcoin",
     },
   ]
 
@@ -36,22 +41,21 @@ export default function ProjectsPage() {
         {projects.map((project) => (
           <Card key={project.id} className="hover:shadow-lg transition-shadow">
             <CardHeader>
-              <img
-                src={project.image || "/placeholder.png"}
-                alt={project.title}
-                className="w-full h-48 object-cover rounded-md mb-4"
-              />
+              <Link href={project.link}>
+                <Image
+                  src={project.image || "/placeholder.png"}
+                  alt={project.title}
+                  width={400}
+                  height={400}
+                  className="w-full aspect-square object-cover rounded-md mb-4"
+                />
+              </Link>
               <CardTitle className="text-2xl mb-2">{project.title}</CardTitle>
               <CardDescription className="mb-4">
-                {project.description}
+                <Link href={project.link} className="hover:underline">
+                  {project.shortDescription}
+                </Link>
               </CardDescription>
-              {project.responsibilities && (
-                <ul className="list-disc list-inside text-sm text-muted-foreground">
-                  {project.responsibilities.map((item) => (
-                    <li key={item}>{item}</li>
-                  ))}
-                </ul>
-              )}
             </CardHeader>
             <CardContent>
               <div className="flex flex-wrap gap-2 mb-4">

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -31,34 +31,34 @@ export default function ProjectsPage() {
   ]
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-4xl font-bold mb-8 text-center">Projects</h1>
-      <p className="text-xl text-muted-foreground text-center mb-12">
+    <div className="container mx-auto px-4 py-4">
+      <h1 className="text-3xl font-bold mb-4 text-center">Projects</h1>
+      <p className="text-lg text-muted-foreground text-center mb-6">
         A collection of my work, showcasing various technologies and problem-solving approaches.
       </p>
 
-      <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {projects.map((project) => (
           <Card key={project.id} className="hover:shadow-lg transition-shadow">
-            <CardHeader>
+            <CardHeader className="p-4">
               <Link href={project.link}>
                 <Image
                   src={project.image || "/placeholder.png"}
                   alt={project.title}
-                  width={400}
-                  height={400}
-                  className="w-full aspect-square object-cover rounded-md mb-4"
+                  width={256}
+                  height={256}
+                  className="w-full aspect-square object-cover rounded-md mb-2"
                 />
               </Link>
-              <CardTitle className="text-2xl mb-2">{project.title}</CardTitle>
-              <CardDescription className="mb-4">
+              <CardTitle className="text-xl mb-1">{project.title}</CardTitle>
+              <CardDescription className="mb-2">
                 <Link href={project.link} className="hover:underline">
                   {project.shortDescription}
                 </Link>
               </CardDescription>
             </CardHeader>
-            <CardContent>
-              <div className="flex flex-wrap gap-2 mb-4">
+            <CardContent className="p-4 pt-0">
+              <div className="flex flex-wrap gap-2 mb-2">
                 {project.tags.map((tag) => (
                   <Badge key={tag} variant="secondary">
                     {tag}

--- a/app/projects/wearebitcoin/page.tsx
+++ b/app/projects/wearebitcoin/page.tsx
@@ -1,0 +1,28 @@
+import Image from "next/image"
+
+export default function WeAreBitcoinPage() {
+  return (
+    <article className="container mx-auto px-4 py-8 prose dark:prose-invert">
+      <h1>WeAreBitcoin.org</h1>
+      <Image
+        src="/wab.png"
+        alt="WeAreBitcoin.org"
+        width={400}
+        height={400}
+        className="rounded-md mb-4"
+      />
+      <p>
+        Content Writer and Developer at WeAreBitcoin.org, a Bitcoin education platform focused on self-custody and sound money principles.
+      </p>
+      <h2>Responsibilities</h2>
+      <ul>
+        <li>Write, translate, and localize articles on Bitcoin, Austrian economics, and self-sovereignty.</li>
+        <li>Format and publish posts using Markdown and a Next.js-based CMS.</li>
+        <li>Design and test interactive tools such as onboarding wizards and DCA calculators.</li>
+        <li>Optimize content for SEO and clarity with strategic headlines and metadata.</li>
+        <li>Collaborate on visual layouts and UX to enhance engagement and learning.</li>
+      </ul>
+      <p>This is a test article for the project page.</p>
+    </article>
+  )
+}

--- a/app/projects/wearebitcoin/page.tsx
+++ b/app/projects/wearebitcoin/page.tsx
@@ -2,27 +2,29 @@ import Image from "next/image"
 
 export default function WeAreBitcoinPage() {
   return (
-    <article className="container mx-auto px-4 py-8 prose dark:prose-invert">
-      <h1>WeAreBitcoin.org</h1>
-      <Image
-        src="/wab.png"
-        alt="WeAreBitcoin.org"
-        width={400}
-        height={400}
-        className="rounded-md mb-4"
-      />
-      <p>
-        Content Writer and Developer at WeAreBitcoin.org, a Bitcoin education platform focused on self-custody and sound money principles.
-      </p>
-      <h2>Responsibilities</h2>
-      <ul>
-        <li>Write, translate, and localize articles on Bitcoin, Austrian economics, and self-sovereignty.</li>
-        <li>Format and publish posts using Markdown and a Next.js-based CMS.</li>
-        <li>Design and test interactive tools such as onboarding wizards and DCA calculators.</li>
-        <li>Optimize content for SEO and clarity with strategic headlines and metadata.</li>
-        <li>Collaborate on visual layouts and UX to enhance engagement and learning.</li>
-      </ul>
-      <p>This is a test article for the project page.</p>
-    </article>
+    <div className="container mx-auto max-w-3xl px-4 py-8">
+      <article className="prose dark:prose-invert">
+        <h1>WeAreBitcoin.org</h1>
+        <Image
+          src="/wab.png"
+          alt="WeAreBitcoin.org"
+          width={400}
+          height={400}
+          className="rounded-md mb-4 w-full max-w-xs aspect-square object-cover"
+        />
+        <p>
+          Content Writer and Developer at WeAreBitcoin.org, a Bitcoin education platform focused on self-custody and sound money principles.
+        </p>
+        <h2>Responsibilities</h2>
+        <ul>
+          <li>Write, translate, and localize articles on Bitcoin, Austrian economics, and self-sovereignty.</li>
+          <li>Format and publish posts using Markdown and a Next.js-based CMS.</li>
+          <li>Design and test interactive tools such as onboarding wizards and DCA calculators.</li>
+          <li>Optimize content for SEO and clarity with strategic headlines and metadata.</li>
+          <li>Collaborate on visual layouts and UX to enhance engagement and learning.</li>
+        </ul>
+        <p>This is a test article for the project page.</p>
+      </article>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- shrink project cards by showing square images and short descriptions
- link project cards to dedicated pages
- add initial WeAreBitcoin.org project article

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688ba4e7f5148326b476b5b171451d24