### PR TITLE
Align blog previews with homepage

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -105,7 +105,7 @@ export default function BlogPage() {
 
   const truncateContent = (content: string, maxLength = 300) => {
     if (content.length <= maxLength) return content
-    return content.substring(0, maxLength) + "..."
+    return content.slice(0, maxLength) + "…"
   }
 
   if (loading) {
@@ -275,13 +275,13 @@ export default function BlogPage() {
                   )}
                 </CardHeader>
                 <CardContent>
-                  <div className="prose prose-sm prose-slate dark:prose-invert max-w-none">
-                    <p className="text-slate-700 dark:text-slate-300 leading-relaxed">
-                      {truncateContent(post.content, 150)}
+                  <div className="prose prose-slate dark:prose-invert max-w-none w-full">
+                    <p className="text-slate-700 dark:text-slate-300 leading-relaxed break-words overflow-hidden line-clamp-3">
+                      {truncateContent(post.content)}
                     </p>
                   </div>
-                  <div className="mt-4">
-                    <Button variant="outline" size="sm" asChild className="w-full bg-transparent">
+                  <div className="mt-4 flex justify-between items-center">
+                    <Button variant="outline" size="sm" asChild>
                       <Link href={`/blog/${post.id}`}>Read More</Link>
                     </Button>
                   </div>


### PR DESCRIPTION
## Summary
- Match blog card excerpts to homepage by truncating content consistently and clamping to 3 lines
- Use a consistent Read More button style on blog cards

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688baa1f220c8326a771f521434679af