### PR TITLE
Center Nostr cards and improve njump button

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { ExternalLink } from "lucide-react"
 import { nostrClient, type NostrPost } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
@@ -53,12 +54,12 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
   return (
     <div className="container mx-auto px-4 py-8">
       <div
-        className="prose dark:prose-invert max-w-none"
+        className="prose dark:prose-invert max-w-2xl mx-auto"
         dangerouslySetInnerHTML={{ __html: renderedContent }}
       />
 
       {tags.length > 0 && (
-        <div className="mt-4 flex flex-wrap gap-2">
+        <div className="mt-4 flex flex-wrap gap-2 justify-center">
           {tags.map((tag) => (
             <Badge key={tag} variant="outline">
               #{tag}
@@ -67,10 +68,11 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
         </div>
       )}
 
-      <div className="mt-8">
-        <Button asChild>
+      <div className="mt-8 flex justify-center">
+        <Button variant="outline" asChild>
           <a href={njumpUrl} target="_blank" rel="noopener noreferrer">
-            Watch on your favorite Nostr clients
+            <ExternalLink className="h-4 w-4 mr-2" />
+            View on Nostr
           </a>
         </Button>
       </div>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -119,7 +119,7 @@ export default function BlogPage() {
             <p className="text-slate-600 dark:text-slate-300">All my thoughts, articles, and notes from Nostr</p>
           </div>
 
-          <div className="space-y-6">
+          <div className="space-y-6 max-w-2xl mx-auto">
             {[...Array(5)].map((_, i) => (
               <Card key={i} className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
                 <CardHeader>
@@ -224,7 +224,7 @@ export default function BlogPage() {
         </Card>
 
         {/* Posts Grid */}
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
           {filteredPosts.length === 0 ? (
             <div className="col-span-full">
               <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">

--- a/app/lifestyle/page.tsx
+++ b/app/lifestyle/page.tsx
@@ -86,7 +86,7 @@ export default function LifestylePage() {
         </TabsList>
 
         <TabsContent value="posts" className="mt-6">
-          <div className="space-y-4">
+          <div className="space-y-4 max-w-2xl mx-auto">
             {loadingPosts ? (
               <p className="text-center text-muted-foreground">Loading...</p>
             ) : posts.length === 0 ? (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -134,7 +134,7 @@ export default function HomePage() {
           </Card>
 
           {/* Posts skeleton */}
-          <div className="space-y-6">
+          <div className="space-y-6 max-w-2xl mx-auto">
             {[...Array(3)].map((_, i) => (
               <Card key={i} className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
                 <CardHeader>
@@ -224,7 +224,7 @@ export default function HomePage() {
 
         {/* Posts */}
         <h2 className="text-2xl font-bold mb-4">Latest Posts</h2>
-        <div className="space-y-6">
+        <div className="space-y-6 max-w-2xl mx-auto">
           {filteredPosts.length === 0 ? (
             <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
               <CardContent className="p-8 text-center">


### PR DESCRIPTION
## Summary
- center Nostr post cards on home, blog, and lifestyle pages for cleaner layout
- streamline blog post view with centered tags and a polished njump link

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688bb5a3872c832690c2063d327931ff