### PR TITLE
feat: center blog post content in card

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { nostrClient, type NostrPost } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
@@ -42,6 +43,18 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
   // Render markdown content
   const renderedContent = marked.parse(post.content || "")
 
+  const formatDate = (timestamp: number) =>
+    new Date(timestamp * 1000).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    })
+
+  const authorName =
+    post.profile?.display_name || post.profile?.name || "Anonymous"
+  const profilePic = post.profile?.picture || "/placeholder-user.jpg"
+  const displayDate = formatDate(post.published_at || post.created_at)
+
   // Extract 't' tags
   const tags = post.tags
     .filter((t) => t[0] === "t" && t[1])
@@ -51,28 +64,47 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
   const njumpUrl = `https://njump.me/${nevent}`
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <div
-        className="prose dark:prose-invert max-w-none"
-        dangerouslySetInnerHTML={{ __html: renderedContent }}
-      />
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
+      <div className="container mx-auto px-4 py-8">
+        <Card className="mx-auto max-w-3xl border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
+          <CardContent className="p-6">
+            <div className="mb-6 flex items-center gap-4">
+              <Avatar className="h-10 w-10">
+                <AvatarImage src={profilePic} alt={authorName} />
+                <AvatarFallback>
+                  {authorName.charAt(0).toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
+              <div>
+                <p className="font-semibold">{authorName}</p>
+                <p className="text-xs text-muted-foreground">{displayDate}</p>
+              </div>
+            </div>
 
-      {tags.length > 0 && (
-        <div className="mt-4 flex flex-wrap gap-2">
-          {tags.map((tag) => (
-            <Badge key={tag} variant="outline">
-              #{tag}
-            </Badge>
-          ))}
-        </div>
-      )}
+            <article
+              className="prose dark:prose-invert max-w-none"
+              dangerouslySetInnerHTML={{ __html: renderedContent }}
+            />
 
-      <div className="mt-8">
-        <Button asChild>
-          <a href={njumpUrl} target="_blank" rel="noopener noreferrer">
-            Watch on your favorite Nostr clients
-          </a>
-        </Button>
+            {tags.length > 0 && (
+              <div className="mt-4 flex flex-wrap gap-2">
+                {tags.map((tag) => (
+                  <Badge key={tag} variant="outline">
+                    #{tag}
+                  </Badge>
+                ))}
+              </div>
+            )}
+
+            <div className="mt-8">
+              <Button asChild>
+                <a href={njumpUrl} target="_blank" rel="noopener noreferrer">
+                  Watch on your favorite Nostr clients
+                </a>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- style individual blog post page using a centered card
- include author avatar and publish date above content

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688bb83159848326b1e3eb69fa93bfa7