### PR TITLE
feat: surface garden notes on home page

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -7,7 +7,7 @@ export default async function SearchPage({
   searchParams: { q?: string; source?: SearchSource }
 }) {
   const query = searchParams.q ?? ''
-  const source = (searchParams.source as SearchSource) ?? 'all'
+  const source = searchParams.source as SearchSource | undefined
   const results = await searchContent(query, source)
 
   return (

--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -8,7 +8,7 @@ import { Search } from "lucide-react"
 
 export function SearchBar() {
   const [term, setTerm] = useState("")
-  const [source, setSource] = useState("all")
+  const [source, setSource] = useState("nostr")
   const router = useRouter()
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -32,10 +32,9 @@ export function SearchBar() {
       </div>
       <Select value={source} onValueChange={setSource}>
         <SelectTrigger className="w-[110px]">
-          <SelectValue placeholder="All" />
+          <SelectValue placeholder="Nostr" />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="all">All</SelectItem>
           <SelectItem value="nostr">Nostr</SelectItem>
           <SelectItem value="article">Articles</SelectItem>
           <SelectItem value="garden">Garden</SelectItem>

--- a/lib/digital-garden.ts
+++ b/lib/digital-garden.ts
@@ -6,6 +6,8 @@ export interface DigitalGardenNote {
   slug: string
   title: string
   tags: string[]
+  date?: string
+  content: string
 }
 
 const notesDir = path.join(process.cwd(), 'digital-garden')
@@ -16,8 +18,8 @@ export async function getAllNotes(): Promise<DigitalGardenNote[]> {
   for (const file of files) {
     if (!file.endsWith('.md')) continue
     const slug = file.replace(/\.md$/, '')
-    const content = await fs.readFile(path.join(notesDir, file), 'utf8')
-    const { data } = matter(content)
+    const raw = await fs.readFile(path.join(notesDir, file), 'utf8')
+    const { data, content } = matter(raw)
     const title = (data as any).title || slug
     const rawTags = (data as any).tags
     const tags = Array.isArray(rawTags)
@@ -25,7 +27,8 @@ export async function getAllNotes(): Promise<DigitalGardenNote[]> {
       : rawTags
       ? [String(rawTags)]
       : []
-    notes.push({ slug, title, tags })
+    const date = (data as any).date as string | undefined
+    notes.push({ slug, title, tags, date, content })
   }
   return notes
 }

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -4,7 +4,7 @@ import matter from 'gray-matter'
 import { fetchNostrPosts } from '@/lib/nostr'
 import { getNostrSettings } from '@/lib/nostr-settings'
 
-export type SearchSource = 'all' | 'nostr' | 'article' | 'garden'
+export type SearchSource = 'nostr' | 'article' | 'garden'
 
 export interface SearchResult {
   type: SearchSource
@@ -13,21 +13,21 @@ export interface SearchResult {
   snippet: string
 }
 
-export async function searchContent(query: string, source: SearchSource = 'all'): Promise<SearchResult[]> {
+export async function searchContent(query: string, source?: SearchSource): Promise<SearchResult[]> {
   const q = query.toLowerCase()
   const results: SearchResult[] = []
 
   const settings = getNostrSettings()
 
-  const includeNostr = source === 'all' || source === 'nostr' || source === 'article'
-  const includeGarden = source === 'all' || source === 'garden'
+  const includeNostr = !source || source === 'nostr' || source === 'article'
+  const includeGarden = !source || source === 'garden'
 
   if (includeNostr && settings.ownerNpub) {
     try {
       const posts = await fetchNostrPosts(settings.ownerNpub, settings.maxPosts)
       for (const post of posts) {
         const postType: SearchSource = post.type === 'article' ? 'article' : 'nostr'
-        if (source !== 'all' && source !== postType) continue
+        if (source && source !== postType) continue
         const text = `${post.title ?? ''} ${post.summary ?? ''} ${post.content}`.toLowerCase()
         if (!q || text.includes(q)) {
           results.push({


### PR DESCRIPTION
## Summary
- include digital garden notes in home-page feed alongside nostr events and articles
- simplify content filters to nostr, articles, and garden across search and latest sections
- expose garden note metadata for downstream use

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688bb64515b48326872c8afdd06e7a15