### PR TITLE
feat: add theme toggle and colorful headings

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -66,6 +66,15 @@
   body {
     @apply bg-background text-foreground;
   }
+  h1 {
+    @apply text-blue-600 dark:text-blue-400;
+  }
+  h2 {
+    @apply text-purple-600 dark:text-purple-400;
+  }
+  h3 {
+    @apply text-green-600 dark:text-green-400;
+  }
 }
 
 /* Custom styles for better typography and spacing */
@@ -83,15 +92,15 @@
 }
 
 .prose h1 {
-  @apply text-3xl mb-4 mt-8 text-slate-900 dark:text-slate-100;
+  @apply text-3xl mb-4 mt-8 text-blue-600 dark:text-blue-400;
 }
 
 .prose h2 {
-  @apply text-2xl mb-3 mt-6 text-slate-900 dark:text-slate-100;
+  @apply text-2xl mb-3 mt-6 text-purple-600 dark:text-purple-400;
 }
 
 .prose h3 {
-  @apply text-xl mb-2 mt-5 text-slate-900 dark:text-slate-100;
+  @apply text-xl mb-2 mt-5 text-green-600 dark:text-green-400;
 }
 
 .prose p {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata, Viewport } from "next"
 import { Inter } from "next/font/google"
 import Script from "next/script"
 import "./globals.css"
-// import { ThemeProvider } from "@/components/theme-provider"
+import { ThemeProvider } from "@/components/theme-provider"
 // import { Navigation } from "@/components/navigation"
 // import { Footer } from "@/components/footer"
 // import { Toaster } from "@/components/ui/toaster"
@@ -50,23 +50,25 @@ export default async function RootLayout({
   const siteName = await getSiteName()
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.className} w-full`}>
-        <Navbar siteName={siteName} />
-        {children}
-        <Script
-          src="https://www.googletagmanager.com/gtag/js?id=G-G8586BX397"
-          strategy="afterInteractive"
-        />
-        <Script id="google-analytics" strategy="afterInteractive">
-          {`
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
+        <body className={`${inter.className} w-full`}>
+          <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+            <Navbar siteName={siteName} />
+            {children}
+          </ThemeProvider>
+          <Script
+            src="https://www.googletagmanager.com/gtag/js?id=G-G8586BX397"
+            strategy="afterInteractive"
+          />
+          <Script id="google-analytics" strategy="afterInteractive">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
 
-            gtag('config', 'G-G8586BX397');
-          `}
-        </Script>
-      </body>
+              gtag('config', 'G-G8586BX397');
+            `}
+          </Script>
+        </body>
     </html>
   )
 }

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { Menu, X } from "lucide-react"
 import Image from "next/image"
 import { SearchBar } from "@/components/search-bar"
+import { ModeToggle } from "@/components/mode-toggle"
 
 interface NavbarProps {
   siteName: string
@@ -41,6 +42,7 @@ export function Navbar({ siteName }: NavbarProps) {
             </Link>
           ))}
           <SearchBar />
+          <ModeToggle />
         </div>
         <button
           className="ml-auto md:hidden"
@@ -61,6 +63,7 @@ export function Navbar({ siteName }: NavbarProps) {
           </button>
           <div className="flex flex-col items-center gap-8 text-lg">
             <SearchBar />
+            <ModeToggle />
             {links.map((link) => (
               <Link
                 key={link.href}


### PR DESCRIPTION
## Summary
- enable light/dark themes across the site and expose a toggle in the navbar
- brighten page titles and subtitles for better visual interest

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688bbae7ac4483268134128c87c67282