### PR TITLE
feat: add theme toggle and colorful headings

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -66,6 +66,12 @@
   body {
     @apply bg-background text-foreground;
   }
+  h1 {
+    @apply text-blue-700 dark:text-blue-300;
+  }
+  h2 {
+    @apply text-purple-700 dark:text-purple-300;
+  }
 }
 
 /* Custom styles for better typography and spacing */
@@ -83,11 +89,11 @@
 }
 
 .prose h1 {
-  @apply text-3xl mb-4 mt-8 text-slate-900 dark:text-slate-100;
+  @apply text-3xl mb-4 mt-8 text-blue-700 dark:text-blue-300;
 }
 
 .prose h2 {
-  @apply text-2xl mb-3 mt-6 text-slate-900 dark:text-slate-100;
+  @apply text-2xl mb-3 mt-6 text-purple-700 dark:text-purple-300;
 }
 
 .prose h3 {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata, Viewport } from "next"
 import { Inter } from "next/font/google"
 import Script from "next/script"
 import "./globals.css"
-// import { ThemeProvider } from "@/components/theme-provider"
+import { ThemeProvider } from "@/components/theme-provider"
 // import { Navigation } from "@/components/navigation"
 // import { Footer } from "@/components/footer"
 // import { Toaster } from "@/components/ui/toaster"
@@ -51,8 +51,10 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.className} w-full`}>
-        <Navbar siteName={siteName} />
-        {children}
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <Navbar siteName={siteName} />
+          {children}
+        </ThemeProvider>
         <Script
           src="https://www.googletagmanager.com/gtag/js?id=G-G8586BX397"
           strategy="afterInteractive"

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { Menu, X } from "lucide-react"
 import Image from "next/image"
 import { SearchBar } from "@/components/search-bar"
+import { ModeToggle } from "@/components/mode-toggle"
 
 interface NavbarProps {
   siteName: string
@@ -41,6 +42,7 @@ export function Navbar({ siteName }: NavbarProps) {
             </Link>
           ))}
           <SearchBar />
+          <ModeToggle />
         </div>
         <button
           className="ml-auto md:hidden"
@@ -61,6 +63,7 @@ export function Navbar({ siteName }: NavbarProps) {
           </button>
           <div className="flex flex-col items-center gap-8 text-lg">
             <SearchBar />
+            <ModeToggle />
             {links.map((link) => (
               <Link
                 key={link.href}


### PR DESCRIPTION
## Summary
- add ThemeProvider and night/day toggle button in navbar
- colorize headings for easier readability

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688bbae7ac4483268134128c87c67282