### PR TITLE
feat: cache profile picture for metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,8 @@ import { ThemeProvider } from "@/components/theme-provider"
 // import { Footer } from "@/components/footer"
 // import { Toaster } from "@/components/ui/toaster"
 import { Navbar } from "@/components/navbar"
-import { getSettings, getSiteName } from "@/lib/settings"
+import { getSettings, getSiteName, getOwnerNpub } from "@/lib/settings"
+import { cacheProfilePicture } from "@/lib/profile-picture-cache"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -21,6 +22,14 @@ export const viewport: Viewport = {
 export async function generateMetadata(): Promise<Metadata> {
   const settings = getSettings()
   const siteName = await getSiteName()
+  const ownerNpub = getOwnerNpub()
+  let profileImage = "/icon.svg"
+  if (ownerNpub) {
+    const cached = await cacheProfilePicture(ownerNpub)
+    if (cached) {
+      profileImage = cached
+    }
+  }
   return {
     title: siteName,
     description: settings.siteDescription,
@@ -31,13 +40,13 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title: siteName,
       description: settings.siteDescription,
-      images: ["/icon.svg"],
+      images: [profileImage],
     },
     twitter: {
       card: "summary",
       title: siteName,
       description: settings.siteDescription,
-      images: ["/icon.svg"],
+      images: [profileImage],
     },
   }
 }

--- a/lib/profile-picture-cache.ts
+++ b/lib/profile-picture-cache.ts
@@ -1,0 +1,31 @@
+import { promises as fs } from "fs"
+import path from "path"
+import { fetchNostrProfile } from "./nostr"
+
+const CACHE_PATH = path.join(process.cwd(), "public", "profile-picture.jpg")
+const MAX_AGE = 24 * 60 * 60 * 1000 // 24 hours
+
+export async function cacheProfilePicture(npub: string): Promise<string | null> {
+  try {
+    const stats = await fs.stat(CACHE_PATH)
+    if (Date.now() - stats.mtimeMs < MAX_AGE) {
+      return "/profile-picture.jpg"
+    }
+  } catch {
+    // File doesn't exist or cannot be accessed
+  }
+
+  try {
+    const profile = await fetchNostrProfile(npub)
+    const url = profile?.picture
+    if (!url) return null
+
+    const res = await fetch(url)
+    if (!res.ok) return null
+    const buffer = Buffer.from(await res.arrayBuffer())
+    await fs.writeFile(CACHE_PATH, buffer)
+    return "/profile-picture.jpg"
+  } catch {
+    return null
+  }
+}

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -36,6 +36,10 @@ export async function getSiteName(): Promise<string> {
   }
 }
 
+export function getOwnerNpub(): string | undefined {
+  return (config as any).nostr?.ownerNpub as string | undefined
+}
+
 // Placeholder to keep API compatibility
 export function saveSettings(_settings: Settings): void {
   // Settings are now stored in settings.json and cannot be changed at runtime


### PR DESCRIPTION
## Summary
- cache the site owner's profile picture and reuse it for metadata images
- expose the owner npub from settings

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688c0c4186088326add7a730dc5e0435