### PR TITLE
Deduplicate Nostr posts and improve blog navigation

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation"
+import Link from "next/link"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -64,10 +65,18 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
   const njumpUrl = `https://njump.me/${nevent}`
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-      <div className="container mx-auto px-4 py-8">
-        <Card className="mx-auto max-w-3xl border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
-          <CardContent className="p-6">
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
+        <div className="container mx-auto px-4 py-8">
+          <div className="mb-4">
+            <Link
+              href="/blog"
+              className="text-blue-600 hover:underline"
+            >
+              ← Back to Blog
+            </Link>
+          </div>
+          <Card className="mx-auto max-w-3xl border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
+            <CardContent className="p-6">
             <div className="mb-6 flex items-center gap-4">
               <Avatar className="h-10 w-10">
                 <AvatarImage src={profilePic} alt={authorName} />

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -237,16 +237,20 @@ export default function BlogPage() {
             </div>
           ) : (
             filteredPosts.map((post) => (
-              <Card
+              <Link
                 key={post.id}
-                className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300"
+                href={`/blog/${post.id}`}
+                className="group block"
               >
-                <CardHeader>
-                  <div className="flex items-center justify-between mb-2">
-                    <Badge variant={post.type === "article" ? "default" : "secondary"}>
-                      {post.type === "article" ? (
-                        <>
-                          <FileText className="h-3 w-3 mr-1" />
+                <Card
+                  className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-1"
+                >
+                  <CardHeader>
+                    <div className="flex items-center justify-between mb-2">
+                      <Badge variant={post.type === "article" ? "default" : "secondary"}>
+                        {post.type === "article" ? (
+                          <>
+                            <FileText className="h-3 w-3 mr-1" />
                           Article
                         </>
                       ) : (
@@ -273,20 +277,16 @@ export default function BlogPage() {
                   {post.summary && (
                     <CardDescription className="text-slate-600 dark:text-slate-300">{post.summary}</CardDescription>
                   )}
-                </CardHeader>
-                <CardContent>
-                  <div className="prose prose-slate dark:prose-invert max-w-none w-full">
-                    <p className="text-slate-700 dark:text-slate-300 leading-relaxed break-words overflow-hidden line-clamp-3">
-                      {truncateContent(post.content)}
-                    </p>
-                  </div>
-                  <div className="mt-4 flex justify-between items-center">
-                    <Button variant="outline" size="sm" asChild>
-                      <Link href={`/blog/${post.id}`}>Read More</Link>
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="prose prose-slate dark:prose-invert max-w-none w-full">
+                      <p className="text-slate-700 dark:text-slate-300 leading-relaxed break-words overflow-hidden line-clamp-3">
+                        {truncateContent(post.content)}
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
             ))
           )}
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -307,61 +307,63 @@ export default function HomePage() {
             </Card>
           ) : (
             filteredPosts.map((post) => (
-              <Card
+              <Link
                 key={post.id}
-                className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300"
+                href={
+                  post.type === "garden"
+                    ? `/digital-garden/${post.id}`
+                    : `/blog/${post.id}`
+                }
+                className="group block"
               >
-                <CardHeader>
-                  <div className="flex items-center justify-between">
-                    <Badge variant={post.type === "article" ? "default" : "secondary"}>
-                      {post.type === "article" ? (
-                        <>
-                          <FileText className="h-3 w-3 mr-1" />
-                          Article
-                        </>
-                      ) : post.type === "garden" ? (
-                        <>
-                          <Leaf className="h-3 w-3 mr-1" />
-                          Garden
-                        </>
-                      ) : (
-                        <>
-                          <MessageSquare className="h-3 w-3 mr-1" />
-                          Nostr
-                        </>
-                      )}
-                    </Badge>
-                    <div className="flex items-center text-sm text-slate-500 dark:text-slate-400">
-                      <Calendar className="h-4 w-4 mr-1" />
-                      {formatDate(post.published_at || post.created_at)}
+                <Card
+                  className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-1"
+                >
+                  <CardHeader>
+                    <div className="flex items-center justify-between">
+                      <Badge variant={post.type === "article" ? "default" : "secondary"}>
+                        {post.type === "article" ? (
+                          <>
+                            <FileText className="h-3 w-3 mr-1" />
+                            Article
+                          </>
+                        ) : post.type === "garden" ? (
+                          <>
+                            <Leaf className="h-3 w-3 mr-1" />
+                            Garden
+                          </>
+                        ) : (
+                          <>
+                            <MessageSquare className="h-3 w-3 mr-1" />
+                            Nostr
+                          </>
+                        )}
+                      </Badge>
+                      <div className="flex items-center text-sm text-slate-500 dark:text-slate-400">
+                        <Calendar className="h-4 w-4 mr-1" />
+                        {formatDate(post.published_at || post.created_at)}
+                      </div>
                     </div>
-                  </div>
-                  {post.title && (
-                    <CardTitle className="text-xl bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
-                      {post.title}
-                    </CardTitle>
-                  )}
-                  {post.summary && (
-                    <CardDescription className="text-slate-600 dark:text-slate-300 leading-relaxed">
-                      {post.summary}
-                    </CardDescription>
-                  )}
-                </CardHeader>
-                <CardContent>
-                  <div className="prose prose-slate dark:prose-invert max-w-none w-full">
-                    <p className="text-slate-700 dark:text-slate-300 leading-relaxed break-words overflow-hidden line-clamp-3">
-                      {truncateContent(post.content)}
-                    </p>
-                  </div>
-                  <div className="mt-4 flex justify-between items-center">
-                    <Button variant="outline" size="sm" asChild>
-                      <Link href={post.type === "garden" ? `/digital-garden/${post.id}` : `/blog/${post.id}`}>
-                        Read More
-                      </Link>
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
+                    {post.title && (
+                      <CardTitle className="text-xl bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
+                        {post.title}
+                      </CardTitle>
+                    )}
+                    {post.summary && (
+                      <CardDescription className="text-slate-600 dark:text-slate-300 leading-relaxed">
+                        {post.summary}
+                      </CardDescription>
+                    )}
+                  </CardHeader>
+                  <CardContent>
+                    <div className="prose prose-slate dark:prose-invert max-w-none w-full">
+                      <p className="text-slate-700 dark:text-slate-300 leading-relaxed break-words overflow-hidden line-clamp-3">
+                        {truncateContent(post.content)}
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
             ))
           )}
         </div>

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -268,11 +268,14 @@ export async function fetchNostrPosts(npub: string, limit = 50): Promise<NostrPo
       return post
     })
 
+    // Remove any duplicate posts that might come from multiple relays
+    const uniquePosts = Array.from(new Map(posts.map((p) => [p.id, p])).values())
+
     // Sort by creation time (newest first)
-    posts.sort((a, b) => b.created_at - a.created_at)
+    uniquePosts.sort((a, b) => b.created_at - a.created_at)
 
     // Limit results
-    const limitedPosts = posts.slice(0, limit)
+    const limitedPosts = uniquePosts.slice(0, limit)
 
     setCachedData(cacheKey, limitedPosts)
     return limitedPosts


### PR DESCRIPTION
## Summary
- filter out duplicate Nostr events when building blog post list
- make entire blog card clickable instead of relying on a button
- add back navigation link to individual blog posts

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688d2f2042c083269b1812a9b4b68840