### PR TITLE
feat: enhance search filter and dark theme

### DIFF
--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -3,7 +3,14 @@
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { Input } from "@/components/ui/input"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { cn } from "@/lib/utils"
 import { Search } from "lucide-react"
 
 export function SearchBar() {
@@ -31,13 +38,26 @@ export function SearchBar() {
         />
       </div>
       <Select value={source} onValueChange={setSource}>
-        <SelectTrigger className="w-[110px]">
-          <SelectValue placeholder="Nostr" />
+        <SelectTrigger
+          className={cn(
+            "w-[130px]",
+            source === "nostr" && "text-purple-500",
+            source === "article" && "text-orange-500",
+            source === "garden" && "text-green-500"
+          )}
+        >
+          <SelectValue placeholder="Filter" />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="nostr">Nostr</SelectItem>
-          <SelectItem value="article">Articles</SelectItem>
-          <SelectItem value="garden">Garden</SelectItem>
+          <SelectItem value="nostr" className="text-purple-500">
+            ⚡ Nostr
+          </SelectItem>
+          <SelectItem value="article" className="text-orange-500">
+            📝 Articles
+          </SelectItem>
+          <SelectItem value="garden" className="text-green-500">
+            🌱 Garden
+          </SelectItem>
         </SelectContent>
       </Select>
     </form>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -49,38 +49,38 @@ body {
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
   .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
+    --background: 222 47% 11%;
+    --foreground: 210 40% 98%;
+    --card: 222 47% 13%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222 47% 13%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 262 83% 75%;
+    --primary-foreground: 0 0% 10%;
+    --secondary: 217 33% 20%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217 33% 20%;
+    --muted-foreground: 215 20% 65%;
+    --accent: 217 33% 20%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62% 40%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
+    --border: 217 33% 20%;
+    --input: 217 33% 20%;
+    --ring: 262 83% 75%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-background: 222 47% 13%;
+    --sidebar-foreground: 210 40% 98%;
+    --sidebar-primary: 262 83% 75%;
+    --sidebar-primary-foreground: 0 0% 10%;
+    --sidebar-accent: 217 33% 22%;
+    --sidebar-accent-foreground: 210 40% 98%;
+    --sidebar-border: 217 33% 20%;
+    --sidebar-ring: 262 83% 75%;
   }
 }
 


### PR DESCRIPTION
## Summary
- add emoji and color-coded options to the search filter
- refresh dark mode color variables for a new look

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688d367005d08326beda7579045e52e6