### PR TITLE
Color-code tags and filters

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -136,7 +136,7 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
             {tags.length > 0 && (
               <div className="mt-4 flex flex-wrap gap-2">
                 {tags.map((tag) => (
-                  <Badge key={tag} variant="outline">
+                  <Badge key={tag} variant="outline" className="border-purple-500 text-purple-500">
                     #{tag}
                   </Badge>
                 ))}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
@@ -196,24 +197,35 @@ export default function BlogPage() {
               </div>
               <div className="flex gap-2">
                 <Button
-                  variant={selectedType === "all" ? "default" : "outline"}
+                  variant="outline"
                   size="sm"
                   onClick={() => setSelectedType("all")}
+                  className={cn(
+                    selectedType === "all" && "bg-slate-200 dark:bg-slate-700",
+                  )}
                 >
                   All ({posts.length})
                 </Button>
                 <Button
-                  variant={selectedType === "note" ? "default" : "outline"}
+                  variant="outline"
                   size="sm"
                   onClick={() => setSelectedType("note")}
+                  className={cn(
+                    "border-purple-500 text-purple-500",
+                    selectedType === "note" && "bg-purple-500 text-white",
+                  )}
                 >
                   <MessageSquare className="h-4 w-4 mr-2" />
                   Notes ({posts.filter((p) => p.type === "note").length})
                 </Button>
                 <Button
-                  variant={selectedType === "article" ? "default" : "outline"}
+                  variant="outline"
                   size="sm"
                   onClick={() => setSelectedType("article")}
+                  className={cn(
+                    "border-orange-500 text-orange-500",
+                    selectedType === "article" && "bg-orange-500 text-white",
+                  )}
                 >
                   <FileText className="h-4 w-4 mr-2" />
                   Articles ({posts.filter((p) => p.type === "article").length})
@@ -247,7 +259,14 @@ export default function BlogPage() {
                 >
                   <CardHeader>
                     <div className="flex items-center justify-between mb-2">
-                      <Badge variant={post.type === "article" ? "default" : "secondary"}>
+                      <Badge
+                        variant="secondary"
+                        className={cn(
+                          post.type === "article"
+                            ? "bg-orange-100 text-orange-700"
+                            : "bg-purple-100 text-purple-700",
+                        )}
+                      >
                         {post.type === "article" ? (
                           <>
                             <FileText className="h-3 w-3 mr-1" />
@@ -259,7 +278,7 @@ export default function BlogPage() {
                           Note
                         </>
                       )}
-                    </Badge>
+                      </Badge>
                     <div className="flex items-center text-xs text-slate-500 dark:text-slate-400">
                       <Calendar className="h-3 w-3 mr-1" />
                       {formatDate(post.published_at || post.created_at)}

--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -22,7 +22,11 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
         {note.tags.length > 0 && (
           <div className="mb-4 flex flex-wrap gap-2">
             {note.tags.map((tag) => (
-              <Badge key={tag} variant="secondary">
+              <Badge
+                key={tag}
+                variant="secondary"
+                className="bg-green-100 text-green-700"
+              >
                 {tag}
               </Badge>
             ))}

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -8,6 +8,7 @@ import {
   CardContent,
 } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
 
 export default async function DigitalGardenPage({
   searchParams,
@@ -33,14 +34,28 @@ export default async function DigitalGardenPage({
       {allTags.length > 0 && (
         <div className="mb-8 flex flex-wrap justify-center gap-2">
           <Link href="/digital-garden">
-            <Badge variant={activeTag ? 'outline' : 'default'}>All</Badge>
+            <Badge
+              variant="outline"
+              className={cn(
+                'border-green-500 text-green-500',
+                !activeTag && 'bg-green-500 text-white',
+              )}
+            >
+              All
+            </Badge>
           </Link>
           {allTags.map((tag) => (
             <Link
               key={tag}
               href={{ pathname: '/digital-garden', query: { tag } }}
             >
-              <Badge variant={activeTag === tag ? 'default' : 'outline'}>
+              <Badge
+                variant="outline"
+                className={cn(
+                  'border-green-500 text-green-500',
+                  activeTag === tag && 'bg-green-500 text-white',
+                )}
+              >
                 {tag}
               </Badge>
             </Link>
@@ -62,7 +77,11 @@ export default async function DigitalGardenPage({
                 <CardContent className="pt-0">
                   <div className="flex flex-wrap gap-2">
                     {note.tags.map((tag) => (
-                      <Badge key={tag} variant="secondary">
+                      <Badge
+                        key={tag}
+                        variant="secondary"
+                        className="bg-green-100 text-green-700"
+                      >
                         {tag}
                       </Badge>
                     ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
@@ -264,37 +265,50 @@ export default function HomePage() {
         {/* Posts */}
         <h2 className="text-2xl font-bold mb-4">Latest Posts</h2>
         <div className="flex gap-2 mb-4">
-          {["nostr", "article", "garden"].map((type) => (
-            <Button
-              key={type}
-              variant={selectedType === type ? "default" : "outline"}
-              size="sm"
-              onClick={() =>
-                setSelectedType(
-                  selectedType === type
-                    ? ""
-                    : (type as "nostr" | "article" | "garden"),
-                )
-              }
-            >
-              {type === "nostr" ? (
-                <>
-                  <MessageSquare className="h-4 w-4 mr-2" />
-                  Nostr
-                </>
-              ) : type === "article" ? (
-                <>
-                  <FileText className="h-4 w-4 mr-2" />
-                  Articles
-                </>
-              ) : (
-                <>
-                  <Leaf className="h-4 w-4 mr-2" />
-                  Garden
-                </>
-              )}
-            </Button>
-          ))}
+          {["nostr", "article", "garden"].map((type) => {
+            const isActive = selectedType === type
+            const color =
+              type === "nostr"
+                ? "purple"
+                : type === "article"
+                ? "orange"
+                : "green"
+            return (
+              <Button
+                key={type}
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  setSelectedType(
+                    selectedType === type
+                      ? ""
+                      : (type as "nostr" | "article" | "garden"),
+                  )
+                }
+                className={cn(
+                  `border-${color}-500 text-${color}-500`,
+                  isActive && `bg-${color}-500 text-white`,
+                )}
+              >
+                {type === "nostr" ? (
+                  <>
+                    <MessageSquare className="h-4 w-4 mr-2" />
+                    Nostr
+                  </>
+                ) : type === "article" ? (
+                  <>
+                    <FileText className="h-4 w-4 mr-2" />
+                    Articles
+                  </>
+                ) : (
+                  <>
+                    <Leaf className="h-4 w-4 mr-2" />
+                    Garden
+                  </>
+                )}
+              </Button>
+            )
+          })}
         </div>
         <div className="space-y-6">
           {filteredPosts.length === 0 ? (
@@ -321,7 +335,16 @@ export default function HomePage() {
                 >
                   <CardHeader>
                     <div className="flex items-center justify-between">
-                      <Badge variant={post.type === "article" ? "default" : "secondary"}>
+                      <Badge
+                        variant="secondary"
+                        className={cn(
+                          post.type === "article"
+                            ? "bg-orange-100 text-orange-700"
+                            : post.type === "garden"
+                            ? "bg-green-100 text-green-700"
+                            : "bg-purple-100 text-purple-700",
+                        )}
+                      >
                         {post.type === "article" ? (
                           <>
                             <FileText className="h-3 w-3 mr-1" />


### PR DESCRIPTION
## Summary
- align site-wide tag and filter colors with search bar scheme
- style home and blog listings with purple/orange/green badges
- update garden pages to use green filters and tags

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688d3b3968308326a370c41a032a5e97