### PR TITLE
feat: add i18n with English and Spanish locales

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -12,6 +12,7 @@ import { useToast } from "@/hooks/use-toast"
 import { sendNostrDM } from "@/lib/nostr-contact"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import { Mail, Send, MessageCircle, CheckCircle } from "lucide-react"
+import { useI18n } from "@/components/locale-provider"
 
 export default function ContactPage() {
   const [formData, setFormData] = useState({
@@ -23,6 +24,7 @@ export default function ContactPage() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isSubmitted, setIsSubmitted] = useState(false)
   const { toast } = useToast()
+  const { t } = useI18n()
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target
@@ -35,8 +37,8 @@ export default function ContactPage() {
     const settings = getNostrSettings()
     if (!settings.ownerNpub) {
       toast({
-        title: "Configuration Error",
-        description: "No Nostr public key configured. Please contact the site administrator.",
+        title: t("contact.configuration_error_title"),
+        description: t("contact.configuration_error_description"),
         variant: "destructive",
       })
       return
@@ -58,8 +60,8 @@ ${formData.message}`
 
       setIsSubmitted(true)
       toast({
-        title: "Message Sent Successfully!",
-        description: "Your message has been sent via Nostr. I'll get back to you soon!",
+        title: t("contact.message_sent_title"),
+        description: t("contact.message_sent_description"),
       })
 
       // Reset form
@@ -72,8 +74,8 @@ ${formData.message}`
     } catch (error) {
       console.error("Error sending message:", error)
       toast({
-        title: "Failed to Send Message",
-        description: "There was an error sending your message. Please try again or contact me directly.",
+        title: t("contact.failed_title"),
+        description: t("contact.failed_description"),
         variant: "destructive",
       })
     } finally {
@@ -88,12 +90,14 @@ ${formData.message}`
           <Card className="max-w-2xl mx-auto backdrop-blur-sm bg-white/80 dark:bg-slate-800/80 border-0 shadow-xl">
             <CardContent className="p-8 text-center">
               <CheckCircle className="h-16 w-16 text-green-500 mx-auto mb-4" />
-              <h2 className="text-2xl font-bold mb-2 text-green-600 dark:text-green-400">Message Sent!</h2>
+              <h2 className="text-2xl font-bold mb-2 text-green-600 dark:text-green-400">
+                {t("contact.message_sent_heading")}
+              </h2>
               <p className="text-slate-600 dark:text-slate-300 mb-6">
-                  Your message has been successfully sent via Nostr. I’ll get back to you as soon as possible.
+                {t("contact.message_sent_text")}
               </p>
               <Button onClick={() => setIsSubmitted(false)} variant="outline">
-                Send Another Message
+                {t("contact.send_another")}
               </Button>
             </CardContent>
           </Card>
@@ -109,10 +113,10 @@ ${formData.message}`
           <CardHeader className="text-center">
             <CardTitle className="text-3xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent flex items-center justify-center gap-2">
               <Mail className="h-8 w-8 text-blue-600" />
-              Contact Me
+              {t("contact.header")}
             </CardTitle>
             <CardDescription className="text-lg">
-                Send me a message via Nostr. I’ll receive it as an encrypted DM and get back to you soon!
+              {t("contact.subheader")}
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -120,12 +124,12 @@ ${formData.message}`
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="name" className="text-sm font-medium">
-                    Name *
+                    {t("contact.name")}
                   </Label>
                   <Input
                     id="name"
                     name="name"
-                    placeholder="Your full name"
+                    placeholder={t("contact.name_placeholder")}
                     value={formData.name}
                     onChange={handleInputChange}
                     required
@@ -134,13 +138,13 @@ ${formData.message}`
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="email" className="text-sm font-medium">
-                    Email *
+                    {t("contact.email")}
                   </Label>
                   <Input
                     id="email"
                     name="email"
                     type="email"
-                    placeholder="your.email@example.com"
+                    placeholder={t("contact.email_placeholder")}
                     value={formData.email}
                     onChange={handleInputChange}
                     required
@@ -151,12 +155,12 @@ ${formData.message}`
 
               <div className="space-y-2">
                 <Label htmlFor="subject" className="text-sm font-medium">
-                  Subject *
+                  {t("contact.subject")}
                 </Label>
                 <Input
                   id="subject"
                   name="subject"
-                  placeholder="What's this about?"
+                  placeholder={t("contact.subject_placeholder")}
                   value={formData.subject}
                   onChange={handleInputChange}
                   required
@@ -166,12 +170,12 @@ ${formData.message}`
 
               <div className="space-y-2">
                 <Label htmlFor="message" className="text-sm font-medium">
-                  Message *
+                  {t("contact.message")}
                 </Label>
                 <Textarea
                   id="message"
                   name="message"
-                  placeholder="Tell me what's on your mind..."
+                  placeholder={t("contact.message_placeholder")}
                   value={formData.message}
                   onChange={handleInputChange}
                   required
@@ -184,11 +188,8 @@ ${formData.message}`
                 <div className="flex items-start gap-3">
                   <MessageCircle className="h-5 w-5 text-blue-600 dark:text-blue-400 mt-0.5" />
                   <div className="text-sm text-blue-800 dark:text-blue-200">
-                    <p className="font-medium mb-1">Sent via Nostr</p>
-                    <p>
-                      Your message will be encrypted and sent as a direct message through the Nostr network. This
-                      ensures privacy and decentralization.
-                    </p>
+                    <p className="font-medium mb-1">{t("contact.sent_via")}</p>
+                    <p>{t("contact.sent_via_description")}</p>
                   </div>
                 </div>
               </div>
@@ -201,12 +202,12 @@ ${formData.message}`
                 {isSubmitting ? (
                   <>
                     <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                    Sending via Nostr...
+                    {t("contact.send")}
                   </>
                 ) : (
                   <>
                     <Send className="h-4 w-4 mr-2" />
-                    Send Message
+                    {t("contact.send")}
                   </>
                 )}
               </Button>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from "@/components/theme-provider"
 import { Navbar } from "@/components/navbar"
 import { getSettings, getSiteName, getOwnerNpub } from "@/lib/settings"
 import { cacheProfilePicture } from "@/lib/profile-picture-cache"
+import { I18nProvider } from "@/components/locale-provider"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -60,10 +61,12 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
         <body className={`${inter.className} w-full`}>
-          <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-            <Navbar siteName={siteName} />
-            {children}
-          </ThemeProvider>
+          <I18nProvider>
+            <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+              <Navbar siteName={siteName} />
+              {children}
+            </ThemeProvider>
+          </I18nProvider>
           <Script
             src="https://www.googletagmanager.com/gtag/js?id=G-G8586BX397"
             strategy="afterInteractive"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import { FileText, MessageSquare, Calendar, ExternalLink, RefreshCw, Leaf } from
 import { fetchNostrProfile, fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
+import { useI18n } from "@/components/locale-provider"
 
 interface NostrProfile {
   name?: string
@@ -58,6 +59,7 @@ export default function HomePage() {
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState("")
   const [selectedType, setSelectedType] = useState<"" | "nostr" | "article" | "garden">("")
+  const { t, locale } = useI18n()
 
   const loadData = async () => {
     try {
@@ -66,7 +68,7 @@ export default function HomePage() {
 
       const settings = getNostrSettings()
       if (!settings.ownerNpub) {
-        setError("No Nostr public key configured. Please update settings.json to add your npub.")
+        setError(t("home.no_npub"))
         return
       }
 
@@ -110,7 +112,7 @@ export default function HomePage() {
       setFilteredPosts(combined)
     } catch (err) {
       console.error("Error loading data:", err)
-      setError("Failed to load data. Please try again.")
+      setError(t("home.failed_load"))
     } finally {
       setLoading(false)
     }
@@ -143,7 +145,7 @@ export default function HomePage() {
   }, [posts, searchTerm, selectedType])
 
   const formatDate = (timestamp: number) => {
-    return new Date(timestamp * 1000).toLocaleDateString("en-US", {
+    return new Date(timestamp * 1000).toLocaleDateString(locale === "es" ? "es-ES" : "en-US", {
       year: "numeric",
       month: "long",
       day: "numeric",
@@ -209,7 +211,7 @@ export default function HomePage() {
               <div className="flex gap-2">
                 <Button onClick={loadData} size="sm" variant="outline">
                   <RefreshCw className="h-4 w-4 mr-2" />
-                  Retry
+                  {t("home.retry")}
                 </Button>
               </div>
             </AlertDescription>
@@ -239,7 +241,7 @@ export default function HomePage() {
                 </Avatar>
                 <div className="flex-1 text-center md:text-left">
                   <h1 className="text-3xl font-bold mb-2 bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
-                    {profile.display_name || profile.name || "Anonymous"}
+                  {profile.display_name || profile.name || t("home.anonymous")}
                   </h1>
                   {profile.about && (
                     <div className="text-slate-600 dark:text-slate-300 mb-4 leading-relaxed prose prose-slate dark:prose-invert max-w-none">
@@ -251,7 +253,7 @@ export default function HomePage() {
                       <Button variant="outline" size="sm" asChild>
                         <a href={profile.website} target="_blank" rel="noopener noreferrer">
                           <ExternalLink className="h-4 w-4 mr-2" />
-                          Website
+                          {t("home.website")}
                         </a>
                       </Button>
                     )}
@@ -263,7 +265,7 @@ export default function HomePage() {
         )}
 
         {/* Posts */}
-        <h2 className="text-2xl font-bold mb-4">Latest Posts</h2>
+        <h2 className="text-2xl font-bold mb-4">{t("home.latest_posts")}</h2>
         <div className="flex gap-2 mb-4">
           {["nostr", "article", "garden"].map((type) => {
             const isActive = selectedType === type
@@ -293,17 +295,17 @@ export default function HomePage() {
                 {type === "nostr" ? (
                   <>
                     <MessageSquare className="h-4 w-4 mr-2" />
-                    Nostr
+                    {t("home.type_nostr")}
                   </>
                 ) : type === "article" ? (
                   <>
                     <FileText className="h-4 w-4 mr-2" />
-                    Articles
+                    {t("home.type_article")}
                   </>
                 ) : (
                   <>
                     <Leaf className="h-4 w-4 mr-2" />
-                    Garden
+                    {t("home.type_garden")}
                   </>
                 )}
               </Button>
@@ -315,7 +317,7 @@ export default function HomePage() {
             <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
               <CardContent className="p-8 text-center">
                 <p className="text-slate-600 dark:text-slate-300">
-                  {posts.length === 0 ? "No posts found." : "No posts match your search criteria."}
+                  {posts.length === 0 ? t("home.no_posts") : t("home.no_posts_match")}
                 </p>
               </CardContent>
             </Card>
@@ -348,17 +350,17 @@ export default function HomePage() {
                         {post.type === "article" ? (
                           <>
                             <FileText className="h-3 w-3 mr-1" />
-                            Article
+                            {t("home.type_article")}
                           </>
                         ) : post.type === "garden" ? (
                           <>
                             <Leaf className="h-3 w-3 mr-1" />
-                            Garden
+                            {t("home.type_garden")}
                           </>
                         ) : (
                           <>
                             <MessageSquare className="h-3 w-3 mr-1" />
-                            Nostr
+                            {t("home.type_nostr")}
                           </>
                         )}
                       </Badge>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,13 +1,21 @@
+"use client"
+
+import { useI18n } from "@/components/locale-provider"
+
 interface FooterProps {
   siteName: string
 }
 
 export function Footer({ siteName }: FooterProps) {
+  const { t } = useI18n()
+
   return (
     <footer className="border-t py-6 text-center text-sm text-muted-foreground">
       <div className="container mx-auto px-4">
-        <p>&copy; {new Date().getFullYear()} {siteName}. All rights reserved.</p>
-        <p className="mt-1">Powered by Nostr and Next.js</p>
+        <p>
+          &copy; {new Date().getFullYear()} {siteName}. {t("footer.rights")}
+        </p>
+        <p className="mt-1">{t("footer.powered")}</p>
       </div>
     </footer>
   )

--- a/components/language-toggle.tsx
+++ b/components/language-toggle.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { useI18n } from "@/components/locale-provider"
+
+export function LanguageToggle() {
+  const { locale, setLocale } = useI18n()
+
+  return (
+    <Select value={locale} onValueChange={(v) => setLocale(v as "en" | "es")}>
+      <SelectTrigger className="w-[80px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="en">EN</SelectItem>
+        <SelectItem value="es">ES</SelectItem>
+      </SelectContent>
+    </Select>
+  )
+}

--- a/components/locale-provider.tsx
+++ b/components/locale-provider.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import React, {createContext, useContext, useState, useEffect, ReactNode} from "react"
+import en from "@/locales/en.json"
+import es from "@/locales/es.json"
+
+type Locale = "en" | "es"
+
+type I18nContextValue = {
+  locale: Locale
+  setLocale: (locale: Locale) => void
+  t: (key: string) => string
+}
+
+const translations: Record<Locale, any> = { en, es }
+
+const I18nContext = createContext<I18nContextValue>({
+  locale: "en",
+  setLocale: () => {},
+  t: (key: string) => key,
+})
+
+function getNested(obj: any, path: string) {
+  return path.split(".").reduce((o, k) => (o ? o[k] : undefined), obj)
+}
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocale] = useState<Locale>(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("locale")
+      if (stored === "en" || stored === "es") {
+        return stored
+      }
+    }
+    return "en"
+  })
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("locale", locale)
+      document.documentElement.lang = locale
+    }
+  }, [locale])
+
+  const t = (key: string) => {
+    const value = getNested(translations[locale], key)
+    return value || key
+  }
+
+  return (
+    <I18nContext.Provider value={{ locale, setLocale, t }}>
+      {children}
+    </I18nContext.Provider>
+  )
+}
+
+export function useI18n() {
+  return useContext(I18nContext)
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -6,23 +6,26 @@ import { Menu, X } from "lucide-react"
 import Image from "next/image"
 import { SearchBar } from "@/components/search-bar"
 import { ModeToggle } from "@/components/mode-toggle"
+import { LanguageToggle } from "@/components/language-toggle"
+import { useI18n } from "@/components/locale-provider"
 
 interface NavbarProps {
   siteName: string
 }
 
 const links = [
-  { name: "Home", href: "/" },
-  { name: "Blog", href: "/blog" },
-  { name: "Projects", href: "/projects" },
-  { name: "Resume", href: "/resume" },
-  { name: "Lifestyle", href: "/lifestyle" },
-  { name: "Garden", href: "/digital-garden" },
-  { name: "Contact", href: "/contact" },
+  { key: "home", href: "/" },
+  { key: "blog", href: "/blog" },
+  { key: "projects", href: "/projects" },
+  { key: "resume", href: "/resume" },
+  { key: "lifestyle", href: "/lifestyle" },
+  { key: "garden", href: "/digital-garden" },
+  { key: "contact", href: "/contact" },
 ]
 
 export function Navbar({ siteName }: NavbarProps) {
   const [open, setOpen] = useState(false)
+  const { t } = useI18n()
 
   return (
     <nav className="border-b bg-background">
@@ -38,16 +41,17 @@ export function Navbar({ siteName }: NavbarProps) {
               href={link.href}
               className="text-muted-foreground hover:text-foreground"
             >
-              {link.name}
+              {t(`navbar.${link.key}`)}
             </Link>
           ))}
           <SearchBar />
+          <LanguageToggle />
           <ModeToggle />
         </div>
         <button
           className="ml-auto md:hidden"
           onClick={() => setOpen(true)}
-          aria-label="Open menu"
+          aria-label={t("navbar.open_menu")}
         >
           <Menu className="h-6 w-6" />
         </button>
@@ -57,13 +61,14 @@ export function Navbar({ siteName }: NavbarProps) {
           <button
             className="absolute right-4 top-4"
             onClick={() => setOpen(false)}
-            aria-label="Close menu"
+            aria-label={t("navbar.close_menu")}
           >
             <X className="h-6 w-6" />
           </button>
           <div className="flex flex-col items-center gap-8 text-lg">
             <SearchBar />
             <ModeToggle />
+            <LanguageToggle />
             {links.map((link) => (
               <Link
                 key={link.href}
@@ -71,7 +76,7 @@ export function Navbar({ siteName }: NavbarProps) {
                 onClick={() => setOpen(false)}
                 className="hover:text-primary"
               >
-                {link.name}
+                {t(`navbar.${link.key}`)}
               </Link>
             ))}
           </div>

--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -12,11 +12,13 @@ import {
 } from "@/components/ui/select"
 import { cn } from "@/lib/utils"
 import { Search } from "lucide-react"
+import { useI18n } from "@/components/locale-provider"
 
 export function SearchBar() {
   const [term, setTerm] = useState("")
   const [source, setSource] = useState("nostr")
   const router = useRouter()
+  const { t } = useI18n()
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -33,7 +35,7 @@ export function SearchBar() {
         <Input
           value={term}
           onChange={(e) => setTerm(e.target.value)}
-          placeholder="Search..."
+          placeholder={t("search.placeholder")}
           className="pl-8 w-40 md:w-64"
         />
       </div>
@@ -46,17 +48,17 @@ export function SearchBar() {
             source === "garden" && "text-green-500"
           )}
         >
-          <SelectValue placeholder="Filter" />
+          <SelectValue placeholder={t("search.filter")} />
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="nostr" className="text-purple-500">
-            ⚡ Nostr
+            {t("search.nostr")}
           </SelectItem>
           <SelectItem value="article" className="text-orange-500">
-            📝 Articles
+            {t("search.articles")}
           </SelectItem>
           <SelectItem value="garden" className="text-green-500">
-            🌱 Garden
+            {t("search.garden")}
           </SelectItem>
         </SelectContent>
       </Select>

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,61 @@
+{
+  "navbar": {
+    "home": "Home",
+    "blog": "Blog",
+    "projects": "Projects",
+    "resume": "Resume",
+    "lifestyle": "Lifestyle",
+    "garden": "Garden",
+    "contact": "Contact",
+    "open_menu": "Open menu",
+    "close_menu": "Close menu"
+  },
+  "footer": {
+    "rights": "All rights reserved.",
+    "powered": "Powered by Nostr and Next.js"
+  },
+  "search": {
+    "placeholder": "Search...",
+    "filter": "Filter",
+    "nostr": "⚡ Nostr",
+    "articles": "📝 Articles",
+    "garden": "🌱 Garden"
+  },
+  "contact": {
+    "configuration_error_title": "Configuration Error",
+    "configuration_error_description": "No Nostr public key configured. Please contact the site administrator.",
+    "message_sent_title": "Message Sent Successfully!",
+    "message_sent_description": "Your message has been sent via Nostr. I'll get back to you soon!",
+    "failed_title": "Failed to Send Message",
+    "failed_description": "There was an error sending your message. Please try again or contact me directly.",
+    "header": "Contact Me",
+    "subheader": "Send me a message via Nostr. I’ll receive it as an encrypted DM and get back to you soon!",
+    "name": "Name *",
+    "name_placeholder": "Your full name",
+    "email": "Email *",
+    "email_placeholder": "your.email@example.com",
+    "subject": "Subject *",
+    "subject_placeholder": "What's this about?",
+    "message": "Message *",
+    "message_placeholder": "Your message",
+    "send": "Send Message",
+    "message_sent_heading": "Message Sent!",
+    "message_sent_text": "Your message has been successfully sent via Nostr. I’ll get back to you as soon as possible.",
+    "send_another": "Send Another Message",
+    "sent_via": "Sent via Nostr",
+    "sent_via_description": "Your message will be encrypted and sent as a direct message through the Nostr network. This ensures privacy and decentralization."
+  },
+  "home": {
+    "no_npub": "No Nostr public key configured. Please update settings.json to add your npub.",
+    "failed_load": "Failed to load data. Please try again.",
+    "retry": "Retry",
+    "latest_posts": "Latest Posts",
+    "website": "Website",
+    "type_nostr": "Nostr",
+    "type_article": "Articles",
+    "type_garden": "Garden",
+    "no_posts": "No posts found.",
+    "no_posts_match": "No posts match your search criteria.",
+    "anonymous": "Anonymous"
+  }
+}

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,61 @@
+{
+  "navbar": {
+    "home": "Inicio",
+    "blog": "Blog",
+    "projects": "Proyectos",
+    "resume": "Currículum",
+    "lifestyle": "Estilo de vida",
+    "garden": "Jardín",
+    "contact": "Contacto",
+    "open_menu": "Abrir menú",
+    "close_menu": "Cerrar menú"
+  },
+  "footer": {
+    "rights": "Todos los derechos reservados.",
+    "powered": "Impulsado por Nostr y Next.js"
+  },
+  "search": {
+    "placeholder": "Buscar...",
+    "filter": "Filtrar",
+    "nostr": "⚡ Nostr",
+    "articles": "📝 Artículos",
+    "garden": "🌱 Jardín"
+  },
+  "contact": {
+    "configuration_error_title": "Error de configuración",
+    "configuration_error_description": "No hay una clave pública de Nostr configurada. Por favor contacte al administrador del sitio.",
+    "message_sent_title": "¡Mensaje enviado con éxito!",
+    "message_sent_description": "Tu mensaje ha sido enviado vía Nostr. ¡Me pondré en contacto contigo pronto!",
+    "failed_title": "Error al enviar el mensaje",
+    "failed_description": "Hubo un error al enviar tu mensaje. Intenta de nuevo o contáctame directamente.",
+    "header": "Contáctame",
+    "subheader": "Envíame un mensaje vía Nostr. Lo recibiré como un DM cifrado y te responderé pronto.",
+    "name": "Nombre *",
+    "name_placeholder": "Tu nombre completo",
+    "email": "Correo electrónico *",
+    "email_placeholder": "tu.correo@ejemplo.com",
+    "subject": "Asunto *",
+    "subject_placeholder": "¿De qué se trata?",
+    "message": "Mensaje *",
+    "message_placeholder": "Tu mensaje",
+    "send": "Enviar mensaje",
+    "message_sent_heading": "¡Mensaje enviado!",
+    "message_sent_text": "Tu mensaje ha sido enviado correctamente vía Nostr. Me pondré en contacto contigo lo antes posible.",
+    "send_another": "Enviar otro mensaje",
+    "sent_via": "Enviado vía Nostr",
+    "sent_via_description": "Tu mensaje será cifrado y enviado como un mensaje directo a través de la red Nostr. Esto garantiza privacidad y descentralización."
+  },
+  "home": {
+    "no_npub": "No se ha configurado una clave pública de Nostr. Por favor actualiza settings.json para agregar tu npub.",
+    "failed_load": "No se pudo cargar la información. Inténtalo de nuevo.",
+    "retry": "Reintentar",
+    "latest_posts": "Últimas publicaciones",
+    "website": "Sitio web",
+    "type_nostr": "Nostr",
+    "type_article": "Artículos",
+    "type_garden": "Jardín",
+    "no_posts": "No se encontraron publicaciones.",
+    "no_posts_match": "Ninguna publicación coincide con tu búsqueda.",
+    "anonymous": "Anónimo"
+  }
+}


### PR DESCRIPTION
## Summary
- add simple i18n provider with English and Spanish locale files
- translate navigation, search, home, and contact pages
- allow language switching via navbar

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688d51e8db308326931ff17602d7c0a5