### PR TITLE
feat: add spanish translations for nostr posts

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -9,6 +9,8 @@ import { nostrClient, type NostrPost } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
 import { nip19 } from "nostr-tools"
+import fs from "fs"
+import path from "path"
 
 export async function generateStaticParams() {
   const settings = getNostrSettings()
@@ -102,6 +104,9 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
   const nevent = nip19.neventEncode({ id: post.id })
   const njumpUrl = `https://njump.me/${nevent}`
 
+  const translationPath = path.join(process.cwd(), "nostr-translations", `${id}.md`)
+  const hasTranslation = fs.existsSync(translationPath)
+
   return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
         <div className="container mx-auto px-4 py-8">
@@ -150,6 +155,16 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
                 </a>
               </Button>
             </div>
+            {hasTranslation && (
+              <div className="mt-4">
+                <Link
+                  href={`/es/note/${id}`}
+                  className="text-blue-600 hover:underline"
+                >
+                  🌐 Read in Spanish
+                </Link>
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/app/es/note/[id]/page.tsx
+++ b/app/es/note/[id]/page.tsx
@@ -1,0 +1,60 @@
+import fs from "fs"
+import path from "path"
+import matter from "gray-matter"
+import { marked } from "marked"
+import { nip19 } from "nostr-tools"
+import { notFound } from "next/navigation"
+import { Card, CardContent } from "@/components/ui/card"
+
+export async function generateStaticParams() {
+  const dir = path.join(process.cwd(), "nostr-translations")
+  if (!fs.existsSync(dir)) return []
+  return fs
+    .readdirSync(dir)
+    .filter((file) => file.endsWith(".md"))
+    .map((file) => ({ id: file.replace(".md", "") }))
+}
+
+export default function TranslatedNotePage({ params }: { params: { id: string } }) {
+  const { id } = params
+  const filePath = path.join(process.cwd(), "nostr-translations", `${id}.md`)
+  if (!fs.existsSync(filePath)) {
+    notFound()
+  }
+  const file = fs.readFileSync(filePath, "utf8")
+  const { data, content } = matter(file)
+  if (data.lang !== "es") {
+    notFound()
+  }
+  const html = marked.parse(content)
+  const nevent = nip19.neventEncode({ id })
+  const njumpUrl = `https://njump.me/${nevent}`
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
+      <div className="container mx-auto px-4 py-8">
+        <Card className="mx-auto max-w-3xl border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
+          <CardContent className="p-6">
+            {data.publishing_date && (
+              <p className="text-xs text-muted-foreground mb-4">{data.publishing_date}</p>
+            )}
+            <article
+              className="prose dark:prose-invert max-w-none"
+              dangerouslySetInnerHTML={{ __html: html }}
+            />
+            <div className="mt-8">
+              <a
+                href={njumpUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline"
+              >
+                Ver publicación original
+              </a>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/create-translation.js
+++ b/create-translation.js
@@ -1,0 +1,26 @@
+const fs = require("fs")
+const path = require("path")
+
+const [noteId, ...rest] = process.argv.slice(2)
+if (!noteId) {
+  console.error("Usage: node create-translation.js <noteId> \"Original English content\"")
+  process.exit(1)
+}
+const content = rest.join(" ")
+const today = new Date().toISOString().split("T")[0]
+
+const output = `---
+lang: es
+publishing_date: ${today}
+---
+
+<!-- TODO: Translate the following -->
+> ${content}
+`
+
+const dir = path.resolve(__dirname, "nostr-translations")
+if (!fs.existsSync(dir)) {
+  fs.mkdirSync(dir)
+}
+fs.writeFileSync(path.join(dir, `${noteId}.md`), output)
+console.log(`Created file: nostr-translations/${noteId}.md`)

--- a/nostr-translations/note1xyzabc123.md
+++ b/nostr-translations/note1xyzabc123.md
@@ -1,0 +1,7 @@
+---
+lang: es
+publishing_date: 2025-08-01
+---
+
+<!-- TODO: Translate the following -->
+> This is the original English content.


### PR DESCRIPTION
## Summary
- detect and link to Spanish translations from blog posts
- add Spanish note route to render translated markdown files
- provide script and sample markdown for translation workflow
- ensure Spanish notes link back to the original Nostr post

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688d5594f5148326bd2b7474d0cb4833