### PR TITLE
feat: add Spanish translations for nostr notes

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -9,6 +9,8 @@ import { nostrClient, type NostrPost } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
 import { nip19 } from "nostr-tools"
+import fs from "fs"
+import path from "path"
 
 export async function generateStaticParams() {
   const settings = getNostrSettings()
@@ -79,6 +81,11 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
     notFound()
   }
 
+  const translationPath = path.resolve(
+    `./nostr-translations/${id}.md`,
+  )
+  const hasTranslation = fs.existsSync(translationPath)
+
   // Render markdown content
   const renderedContent = marked.parse(post.content || "")
 
@@ -132,6 +139,17 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
               className="prose dark:prose-invert max-w-none"
               dangerouslySetInnerHTML={{ __html: renderedContent }}
             />
+
+            {hasTranslation && (
+              <div className="mt-4">
+                <Link
+                  href={`/es/note/${id}`}
+                  className="text-blue-600 hover:underline"
+                >
+                  🌐 Read in Spanish
+                </Link>
+              </div>
+            )}
 
             {tags.length > 0 && (
               <div className="mt-4 flex flex-wrap gap-2">

--- a/app/es/note/[id]/page.tsx
+++ b/app/es/note/[id]/page.tsx
@@ -1,0 +1,61 @@
+import fs from 'fs'
+import path from 'path'
+import matter from 'gray-matter'
+import { marked } from 'marked'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+export async function generateStaticParams() {
+  const dir = path.join(process.cwd(), 'nostr-translations')
+  if (!fs.existsSync(dir)) return []
+  return fs
+    .readdirSync(dir)
+    .filter((file) => file.endsWith('.md'))
+    .map((file) => ({ id: file.replace('.md', '') }))
+}
+
+export default function SpanishNotePage({ params }: { params: { id: string } }) {
+  const filePath = path.join(
+    process.cwd(),
+    'nostr-translations',
+    `${params.id}.md`,
+  )
+  if (!fs.existsSync(filePath)) {
+    notFound()
+  }
+  const file = fs.readFileSync(filePath, 'utf8')
+  const { content, data } = matter(file)
+  const html = marked.parse(content)
+  const publishDate = data.publishing_date
+    ? new Date(data.publishing_date).toLocaleDateString('es-ES', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : ''
+  const njumpUrl = `https://njump.me/${params.id}`
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-4">
+          <Link href={`/blog/${params.id}`} className="text-blue-600 hover:underline">
+            ← Ver original
+          </Link>
+        </div>
+        {publishDate && (
+          <p className="text-sm text-slate-500 mb-4">{publishDate}</p>
+        )}
+        <article
+          className="prose dark:prose-invert max-w-none"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+        <div className="mt-8">
+          <Link href={njumpUrl} className="text-blue-600 hover:underline">
+            Ver publicación original
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/create-translation.js
+++ b/create-translation.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+const [noteId, ...rest] = process.argv.slice(2);
+const content = rest.join(' ');
+const today = new Date().toISOString().split('T')[0];
+
+const output = `---\nlang: es\npublishing_date: ${today}\n---\n\n<!-- TODO: Translate the following -->\n> ${content}\n`;
+
+fs.writeFileSync(path.join(__dirname, 'nostr-translations', `${noteId}.md`), output);
+console.log(`Created file: nostr-translations/${noteId}.md`);

--- a/nostr-translations/example-note.md
+++ b/nostr-translations/example-note.md
@@ -1,0 +1,7 @@
+---
+lang: es
+publishing_date: 2025-08-01
+---
+
+<!-- TODO: Translate the following -->
+> This is the original English content.


### PR DESCRIPTION
## Summary
- serve Spanish note translations from local markdown files
- detect translations on English note pages and link to `/es/note/[id]`
- add helper script to scaffold translation files

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688d59dc5ee88326b2901c4b265583b5