### PR TITLE
feat: add infrastructure for Spanish Nostr note translations

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -9,6 +9,8 @@ import { nostrClient, type NostrPost } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
 import { nip19 } from "nostr-tools"
+import fs from "fs"
+import path from "path"
 
 export async function generateStaticParams() {
   const settings = getNostrSettings()
@@ -82,6 +84,9 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
   // Render markdown content
   const renderedContent = marked.parse(post.content || "")
 
+  const translationPath = path.resolve(`./nostr-translations/${post.id}.md`)
+  const hasTranslation = fs.existsSync(translationPath)
+
   const formatDate = (timestamp: number) =>
     new Date(timestamp * 1000).toLocaleDateString("en-US", {
       year: "numeric",
@@ -150,6 +155,16 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
                 </a>
               </Button>
             </div>
+            {hasTranslation && (
+              <div className="mt-4">
+                <Link
+                  href={`/es/note/${post.id}`}
+                  className="text-blue-600 hover:underline"
+                >
+                  🌐 Read in Spanish
+                </Link>
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/app/es/note/[note_id]/page.tsx
+++ b/app/es/note/[note_id]/page.tsx
@@ -1,0 +1,64 @@
+import fs from "fs"
+import path from "path"
+import matter from "gray-matter"
+import { marked } from "marked"
+import Link from "next/link"
+import { Card, CardContent } from "@/components/ui/card"
+
+export async function generateStaticParams() {
+  const dir = path.join(process.cwd(), "nostr-translations")
+  let files: string[] = []
+  try {
+    files = fs.readdirSync(dir)
+  } catch {
+    return []
+  }
+  return files
+    .filter((file) => file.endsWith(".md"))
+    .map((file) => ({ note_id: file.replace(/\.md$/, "") }))
+}
+
+export default function SpanishNotePage({
+  params,
+}: {
+  params: { note_id: string }
+}) {
+  const filePath = path.join(
+    process.cwd(),
+    "nostr-translations",
+    `${params.note_id}.md`
+  )
+  const file = fs.readFileSync(filePath, "utf8")
+  const { data, content } = matter(file)
+  const html = marked.parse(content)
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <Card className="mx-auto max-w-3xl border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
+        <CardContent className="p-6">
+          {data.publishing_date && (
+            <p className="text-sm text-muted-foreground mb-4">
+              {new Date(data.publishing_date).toLocaleDateString("es-ES", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </p>
+          )}
+          <article
+            className="prose dark:prose-invert max-w-none"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+          <div className="mt-8">
+            <Link
+              href={`/blog/${params.note_id}`}
+              className="text-blue-600 hover:underline"
+            >
+              View original post
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/create-translation.js
+++ b/create-translation.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const [noteId, ...rest] = process.argv.slice(2);
+if (!noteId || rest.length === 0) {
+  console.error('Usage: node create-translation.js <noteId> "<original content>"');
+  process.exit(1);
+}
+const content = rest.join(' ');
+const today = new Date().toISOString().split('T')[0];
+
+const output = `---\nlang: es\npublishing_date: ${today}\n---\n\n<!-- TODO: Translate the following -->\n> ${content}\n`;
+
+const dir = path.join(__dirname, 'nostr-translations');
+if (!fs.existsSync(dir)) {
+  fs.mkdirSync(dir);
+}
+
+const filePath = path.join(dir, `${noteId}.md`);
+fs.writeFileSync(filePath, output);
+console.log(`Created file: nostr-translations/${noteId}.md`);

--- a/nostr-translations/example-note.md
+++ b/nostr-translations/example-note.md
@@ -1,0 +1,7 @@
+---
+lang: es
+publishing_date: 2025-01-01
+---
+
+<!-- TODO: Translate the following -->
+> Example note content.


### PR DESCRIPTION
## Summary
- render markdown-based Spanish translations under `/es/note/[id]`
- detect existing translations on English blog posts and link to them
- add helper script for creating translation files

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d59dc5ee88326b2901c4b265583b5