### PR TITLE
Add Spanish translations for Nostr notes

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -9,6 +9,8 @@ import { nostrClient, type NostrPost } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
 import { nip19 } from "nostr-tools"
+import fs from "fs"
+import path from "path"
 
 export async function generateStaticParams() {
   const settings = getNostrSettings()
@@ -78,6 +80,8 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
   if (!post) {
     notFound()
   }
+  const translationPath = path.join(process.cwd(), "nostr-translations", `${id}.md`)
+  const hasTranslation = fs.existsSync(translationPath)
 
   // Render markdown content
   const renderedContent = marked.parse(post.content || "")
@@ -140,6 +144,13 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
                     #{tag}
                   </Badge>
                 ))}
+              </div>
+            )}
+            {hasTranslation && (
+              <div className="mt-8">
+                <Link href={`/es/note/${id}`} className="text-blue-600 hover:underline">
+                  🌐 Read in Spanish
+                </Link>
               </div>
             )}
 

--- a/app/es/note/[id]/page.tsx
+++ b/app/es/note/[id]/page.tsx
@@ -1,0 +1,43 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import { marked } from "marked";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+export async function generateStaticParams() {
+  const dir = path.join(process.cwd(), "nostr-translations");
+  const files = fs.readdirSync(dir);
+  return files
+    .filter((file) => file.endsWith(".md"))
+    .map((file) => ({ id: file.replace(".md", "") }));
+}
+
+export default function SpanishNotePage({ params }: { params: { id: string } }) {
+  const { id } = params;
+  const filePath = path.join(process.cwd(), "nostr-translations", `${id}.md`);
+  if (!fs.existsSync(filePath)) {
+    notFound();
+  }
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const { data, content } = matter(raw);
+  const html = marked.parse(content);
+  const publishDate = data.publishing_date;
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      {publishDate && (
+        <p className="text-sm text-slate-500 mb-4">{publishDate}</p>
+      )}
+      <article
+        className="prose dark:prose-invert max-w-none"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+      <div className="mt-4">
+        <Link href={`/blog/${id}`} className="text-blue-600 hover:underline">
+          View original post
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/create-translation.js
+++ b/create-translation.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+
+const [noteId, ...rest] = process.argv.slice(2);
+if (!noteId) {
+  console.error('Usage: node create-translation.js <noteId> "original English content"');
+  process.exit(1);
+}
+const content = rest.join(' ');
+const today = new Date().toISOString().split('T')[0];
+
+const output = `---
+lang: es
+publishing_date: ${today}
+---
+
+<!-- TODO: Translate the following -->
+> ${content}
+`;
+
+const filePath = path.join(__dirname, 'nostr-translations', `${noteId}.md`);
+fs.writeFileSync(filePath, output);
+console.log(`Created file: nostr-translations/${noteId}.md`);


### PR DESCRIPTION
## Summary
- Detect local Spanish translations for Nostr notes and link from English blog posts
- Render Spanish note pages from Markdown with automatic route generation
- Add helper script to scaffold translation files

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d59dc5ee88326b2901c4b265583b5