### PR TITLE
feat: support note ids for translations

### DIFF
--- a/app/api/nostr-translations/[id]/route.ts
+++ b/app/api/nostr-translations/[id]/route.ts
@@ -2,13 +2,28 @@ import { NextResponse } from "next/server";
 import path from "path";
 import { promises as fs } from "fs";
 import matter from "gray-matter";
+import { nip19 } from "nostr-tools";
 
 export async function GET(
   request: Request,
   { params }: { params: { id: string } }
 ) {
   try {
-    const filePath = path.join(process.cwd(), "nostr-translations", `${params.id}.md`);
+    let id = params.id;
+    if (!/^[0-9a-f]{64}$/.test(id)) {
+      try {
+        const decoded = nip19.decode(id);
+        if (typeof decoded.data === "string") id = decoded.data;
+      } catch {
+        // If decoding fails, the id will remain unchanged
+      }
+    }
+
+    const filePath = path.join(
+      process.cwd(),
+      "nostr-translations",
+      `${id}.md`,
+    );
     const raw = await fs.readFile(filePath, "utf8");
     const { data, content } = matter(raw);
     return NextResponse.json({ data, content });

--- a/nostr-translations/66494eb2b1dec8f5ccd4ddd900c43ee9fc1b7eb7d0bd3ac86491efeba022c650.md
+++ b/nostr-translations/66494eb2b1dec8f5ccd4ddd900c43ee9fc1b7eb7d0bd3ac86491efeba022c650.md
@@ -5,4 +5,4 @@ type: article
 kind: 1
 tags: [bitcoin, censorship, freedom]
 ---
-Esta es una traducción de prueba para una nota de Nostr.
+Esta es una traducción de prueba en español para un evento de Nostr.


### PR DESCRIPTION
## Summary
- allow fetching manual Nostr translations using note IDs
- update sample Spanish translation

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688d704452788326b763d3bed69da289