### PR TITLE
feat: support note id translations

### DIFF
--- a/app/api/nostr-translations/[id]/route.ts
+++ b/app/api/nostr-translations/[id]/route.ts
@@ -2,13 +2,26 @@ import { NextResponse } from "next/server";
 import path from "path";
 import { promises as fs } from "fs";
 import matter from "gray-matter";
+import { nip19 } from "nostr-tools";
 
 export async function GET(
   request: Request,
   { params }: { params: { id: string } }
 ) {
   try {
-    const filePath = path.join(process.cwd(), "nostr-translations", `${params.id}.md`);
+    let id = params.id;
+    if (id.startsWith("note")) {
+      try {
+        const decoded = nip19.decode(id);
+        if (decoded.type === "note") {
+          id = decoded.data as string;
+        }
+      } catch {
+        // ignore decode errors and try as-is
+      }
+    }
+
+    const filePath = path.join(process.cwd(), "nostr-translations", `${id}.md`);
     const raw = await fs.readFile(filePath, "utf8");
     const { data, content } = matter(raw);
     return NextResponse.json({ data, content });

--- a/nostr-translations/66494eb2b1dec8f5ccd4ddd900c43ee9fc1b7eb7d0bd3ac86491efeba022c650.md
+++ b/nostr-translations/66494eb2b1dec8f5ccd4ddd900c43ee9fc1b7eb7d0bd3ac86491efeba022c650.md
@@ -5,4 +5,6 @@ type: article
 kind: 1
 tags: [bitcoin, censorship, freedom]
 ---
-Esta es una traducción de prueba para una nota de Nostr.
+Esta es una traducción de prueba para el evento
+note1vey5av43mmy0tnx5mhvsp3p7a87pkl4h6z7n4jryj8h7hgpzcegqw43qht
+en la red Nostr.


### PR DESCRIPTION
## Summary
- allow API to accept bech32 `note` ids for nostr translations
- normalize `note` ids when fetching nostr posts and their manual Spanish translations
- add sample Spanish translation for test event

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688d704452788326b763d3bed69da289