### PR TITLE
Fix locale handling for Nostr translations

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -50,7 +50,7 @@ export default function BlogPage() {
   const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
   const { locale } = useI18n()
 
-  const loadPosts = async () => {
+  const loadPosts = useCallback(async () => {
     try {
       setLoading(true)
       setError(null)
@@ -70,11 +70,11 @@ export default function BlogPage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [locale])
 
   useEffect(() => {
     loadPosts()
-  }, [])
+  }, [loadPosts])
 
   useEffect(() => {
     let filtered = posts
@@ -99,11 +99,14 @@ export default function BlogPage() {
   }, [posts, searchTerm, selectedType])
 
   const formatDate = (timestamp: number) => {
-    return new Date(timestamp * 1000).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    })
+    return new Date(timestamp * 1000).toLocaleDateString(
+      locale === "es" ? "es-ES" : "en-US",
+      {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      },
+    )
   }
 
   const truncateContent = (content: string, maxLength = 300) => {

--- a/app/lifestyle/page.tsx
+++ b/app/lifestyle/page.tsx
@@ -73,7 +73,7 @@ export default function LifestylePage() {
     }
 
     loadPosts()
-  }, [])
+  }, [locale])
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -102,7 +102,9 @@ export default function LifestylePage() {
                         {post.title || "Note"}
                       </CardTitle>
                       <span className="text-sm text-muted-foreground">
-                        {new Date(post.created_at * 1000).toLocaleDateString()}
+                        {new Date(post.created_at * 1000).toLocaleDateString(
+                          locale === "es" ? "es-ES" : "en-US",
+                        )}
                       </span>
                     </div>
                   </CardHeader>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -61,7 +61,7 @@ export default function HomePage() {
   const [selectedType, setSelectedType] = useState<"" | "nostr" | "article" | "garden">("")
   const { t, locale } = useI18n()
 
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       setLoading(true)
       setError(null)
@@ -116,11 +116,11 @@ export default function HomePage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [locale, t])
 
   useEffect(() => {
     loadData()
-  }, [])
+  }, [loadData])
 
   useEffect(() => {
     let filtered = posts

--- a/components/locale-provider.tsx
+++ b/components/locale-provider.tsx
@@ -39,6 +39,7 @@ export function I18nProvider({ children }: { children: ReactNode }) {
     if (typeof window !== "undefined") {
       localStorage.setItem("locale", locale)
       document.documentElement.lang = locale
+      document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=31536000`
     }
   }, [locale])
 

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -172,7 +172,7 @@ export async function fetchNostrPosts(
   locale = "en"
 ): Promise<NostrPost[]> {
   try {
-    const cacheKey = getCacheKey("posts", `${npub}:${limit}`)
+    const cacheKey = getCacheKey("posts", `${npub}:${limit}:${locale}`)
 
     // Check cache first
     let cached = getCachedData(cacheKey)
@@ -333,7 +333,7 @@ export async function fetchNostrPost(
       }
     }
 
-    const cacheKey = getCacheKey("post", eventId)
+    const cacheKey = getCacheKey("post", `${eventId}:${locale}`)
 
     // Check cache first
     let cached = getCachedData(cacheKey)


### PR DESCRIPTION
## Summary
- ensure Nostr posts cache per locale
- persist selected locale in cookies and re-fetch posts when switching languages
- render blog post pages with locale-aware translations and dates

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688d73637d9483269cf679a038bae8be