### PR TITLE
Fix locale translations for Nostr posts

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -1,14 +1,9 @@
 import { notFound } from "next/navigation"
 import type { Metadata } from "next"
-import Link from "next/link"
-import { Card, CardContent } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { nostrClient, type NostrPost } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
-import { marked } from "marked" // For Markdown rendering
-import { nip19 } from "nostr-tools"
+import BlogPostClient from "@/components/blog-post-client"
+import { Card, CardContent } from "@/components/ui/card"
 
 export async function generateStaticParams() {
   const settings = getNostrSettings()
@@ -78,81 +73,5 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
   if (!post) {
     notFound()
   }
-
-  // Render markdown content
-  const renderedContent = marked.parse(post.content || "")
-
-  const formatDate = (timestamp: number) =>
-    new Date(timestamp * 1000).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    })
-
-  const authorName =
-    post.profile?.display_name || post.profile?.name || "Anonymous"
-  const profilePic = post.profile?.picture || "/placeholder-user.jpg"
-  const displayDate = formatDate(post.published_at || post.created_at)
-
-  // Extract 't' tags
-  const tags = post.tags
-    .filter((t) => t[0] === "t" && t[1])
-    .map((t) => t[1]!)
-
-  const nevent = nip19.neventEncode({ id: post.id })
-  const njumpUrl = `https://njump.me/${nevent}`
-
-  return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
-        <div className="container mx-auto px-4 py-8">
-          <div className="mb-4">
-            <Link
-              href="/blog"
-              className="text-blue-600 hover:underline"
-            >
-              ← Back to Blog
-            </Link>
-          </div>
-          <Card className="mx-auto max-w-3xl border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
-            <CardContent className="p-6">
-            <div className="mb-6 flex items-center gap-4">
-              <Avatar className="h-10 w-10">
-                <AvatarImage src={profilePic} alt={authorName} />
-                <AvatarFallback>
-                  {authorName.charAt(0).toUpperCase()}
-                </AvatarFallback>
-              </Avatar>
-              <div>
-                <p className="font-semibold">{authorName}</p>
-                <p className="text-xs text-muted-foreground">{displayDate}</p>
-              </div>
-            </div>
-
-            <article
-              className="prose dark:prose-invert max-w-none"
-              dangerouslySetInnerHTML={{ __html: renderedContent }}
-            />
-
-            {tags.length > 0 && (
-              <div className="mt-4 flex flex-wrap gap-2">
-                {tags.map((tag) => (
-                  <Badge key={tag} variant="outline" className="border-purple-500 text-purple-500">
-                    #{tag}
-                  </Badge>
-                ))}
-              </div>
-            )}
-
-            <div className="mt-8">
-              <Button asChild>
-                <a href={njumpUrl} target="_blank" rel="noopener noreferrer">
-                  Watch on your favorite Nostr clients
-                </a>
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
-  )
+  return <BlogPostClient initialPost={post} />
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -50,7 +50,7 @@ export default function BlogPage() {
   const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
   const { locale } = useI18n()
 
-  const loadPosts = async () => {
+  const loadPosts = useCallback(async () => {
     try {
       setLoading(true)
       setError(null)
@@ -70,11 +70,11 @@ export default function BlogPage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [locale])
 
   useEffect(() => {
     loadPosts()
-  }, [])
+  }, [loadPosts])
 
   useEffect(() => {
     let filtered = posts
@@ -99,11 +99,14 @@ export default function BlogPage() {
   }, [posts, searchTerm, selectedType])
 
   const formatDate = (timestamp: number) => {
-    return new Date(timestamp * 1000).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    })
+    return new Date(timestamp * 1000).toLocaleDateString(
+      locale === "es" ? "es-ES" : "en-US",
+      {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      },
+    )
   }
 
   const truncateContent = (content: string, maxLength = 300) => {

--- a/app/lifestyle/page.tsx
+++ b/app/lifestyle/page.tsx
@@ -73,7 +73,7 @@ export default function LifestylePage() {
     }
 
     loadPosts()
-  }, [])
+  }, [locale])
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -61,7 +61,7 @@ export default function HomePage() {
   const [selectedType, setSelectedType] = useState<"" | "nostr" | "article" | "garden">("")
   const { t, locale } = useI18n()
 
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       setLoading(true)
       setError(null)
@@ -116,11 +116,11 @@ export default function HomePage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [t, locale])
 
   useEffect(() => {
     loadData()
-  }, [])
+  }, [loadData])
 
   useEffect(() => {
     let filtered = posts

--- a/components/blog-post-client.tsx
+++ b/components/blog-post-client.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { useI18n } from "@/components/locale-provider"
+import { nostrClient, type NostrPost } from "@/lib/nostr"
+import { marked } from "marked"
+import { nip19 } from "nostr-tools"
+
+export default function BlogPostClient({ initialPost }: { initialPost: NostrPost }) {
+  const { locale } = useI18n()
+  const [post, setPost] = useState<NostrPost>(initialPost)
+
+  useEffect(() => {
+    async function load() {
+      const fetched = await nostrClient.fetchPost(initialPost.id, locale)
+      if (fetched) {
+        setPost(fetched)
+      }
+    }
+    load()
+  }, [initialPost.id, locale])
+
+  const renderedContent = marked.parse(post.content || "")
+  const formatDate = (timestamp: number) =>
+    new Date(timestamp * 1000).toLocaleDateString(locale === "es" ? "es-ES" : "en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    })
+
+  const authorName = post.profile?.display_name || post.profile?.name || "Anonymous"
+  const profilePic = post.profile?.picture || "/placeholder-user.jpg"
+  const displayDate = formatDate(post.published_at || post.created_at)
+
+  const tags = post.tags.filter((t) => t[0] === "t" && t[1]).map((t) => t[1]!)
+  const nevent = nip19.neventEncode({ id: post.id })
+  const njumpUrl = `https://njump.me/${nevent}`
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-4">
+          <Link href="/blog" className="text-blue-600 hover:underline">
+            ← Back to Blog
+          </Link>
+        </div>
+        <Card className="mx-auto max-w-3xl border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
+          <CardContent className="p-6">
+            <div className="mb-6 flex items-center gap-4">
+              <Avatar className="h-10 w-10">
+                <AvatarImage src={profilePic} alt={authorName} />
+                <AvatarFallback>{authorName.charAt(0).toUpperCase()}</AvatarFallback>
+              </Avatar>
+              <div>
+                <p className="font-semibold">{authorName}</p>
+                <p className="text-xs text-muted-foreground">{displayDate}</p>
+              </div>
+            </div>
+
+            <article
+              className="prose dark:prose-invert max-w-none"
+              dangerouslySetInnerHTML={{ __html: renderedContent }}
+            />
+
+            {tags.length > 0 && (
+              <div className="mt-4 flex flex-wrap gap-2">
+                {tags.map((tag) => (
+                  <Badge key={tag} variant="outline" className="border-purple-500 text-purple-500">
+                    #{tag}
+                  </Badge>
+                ))}
+              </div>
+            )}
+
+            <div className="mt-8">
+              <Button asChild>
+                <a href={njumpUrl} target="_blank" rel="noopener noreferrer">
+                  Watch on your favorite Nostr clients
+                </a>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- ensure Spanish translations fall back to original content when not available
- reload homepage and blog posts when locale changes
- add client-side blog post renderer that fetches translations per locale

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688d73637d9483269cf679a038bae8be