### PR TITLE
Refetch Nostr posts when locale changes

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -50,7 +50,7 @@ export default function BlogPage() {
   const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
   const { locale } = useI18n()
 
-  const loadPosts = async () => {
+  const loadPosts = useCallback(async () => {
     try {
       setLoading(true)
       setError(null)
@@ -70,11 +70,11 @@ export default function BlogPage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [locale])
 
   useEffect(() => {
     loadPosts()
-  }, [])
+  }, [loadPosts])
 
   useEffect(() => {
     let filtered = posts
@@ -99,11 +99,14 @@ export default function BlogPage() {
   }, [posts, searchTerm, selectedType])
 
   const formatDate = (timestamp: number) => {
-    return new Date(timestamp * 1000).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    })
+    return new Date(timestamp * 1000).toLocaleDateString(
+      locale === "es" ? "es-ES" : "en-US",
+      {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      },
+    )
   }
 
   const truncateContent = (content: string, maxLength = 300) => {

--- a/app/lifestyle/page.tsx
+++ b/app/lifestyle/page.tsx
@@ -73,7 +73,7 @@ export default function LifestylePage() {
     }
 
     loadPosts()
-  }, [])
+  }, [locale])
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -102,7 +102,9 @@ export default function LifestylePage() {
                         {post.title || "Note"}
                       </CardTitle>
                       <span className="text-sm text-muted-foreground">
-                        {new Date(post.created_at * 1000).toLocaleDateString()}
+                        {new Date(post.created_at * 1000).toLocaleDateString(
+                          locale === "es" ? "es-ES" : "en-US",
+                        )}
                       </span>
                     </div>
                   </CardHeader>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -61,7 +61,7 @@ export default function HomePage() {
   const [selectedType, setSelectedType] = useState<"" | "nostr" | "article" | "garden">("")
   const { t, locale } = useI18n()
 
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       setLoading(true)
       setError(null)
@@ -116,11 +116,11 @@ export default function HomePage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [locale, t])
 
   useEffect(() => {
     loadData()
-  }, [])
+  }, [loadData])
 
   useEffect(() => {
     let filtered = posts


### PR DESCRIPTION
## Summary
- Refresh homepage posts when switching EN/ES locales
- Reload blog and lifestyle Nostr posts on locale change and format dates per locale
- Ensure locale toggle updates translations consistently

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688d73637d9483269cf679a038bae8be