### PR TITLE
fix: render profile bio line breaks

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -245,7 +245,7 @@ export default function HomePage() {
                   </h1>
                   {profile.about && (
                     <div className="text-slate-600 dark:text-slate-300 mb-4 leading-relaxed prose prose-slate dark:prose-invert max-w-none">
-                      <p>{profile.about}</p>
+                      <p className="whitespace-pre-line">{profile.about}</p>
                     </div>
                   )}
                   <div className="flex flex-wrap gap-4 justify-center md:justify-start">


### PR DESCRIPTION
## Summary
- preserve Nostr profile bio line breaks

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688d7b0780888326b6dc17d3e9ea29a9