### PR TITLE
Fix Spanish translations for digital garden and blog

### DIFF
--- a/app/api/digital-garden/route.ts
+++ b/app/api/digital-garden/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
 import { getAllNotes } from '@/lib/digital-garden'
 
 export async function GET() {
-  const notes = await getAllNotes()
+  const locale = cookies().get('NEXT_LOCALE')?.value || 'en'
+  const notes = await getAllNotes(locale)
   return NextResponse.json(notes)
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -48,7 +48,7 @@ export default function BlogPage() {
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState("")
   const [selectedType, setSelectedType] = useState<"all" | "note" | "article">("all")
-  const { locale } = useI18n()
+  const { locale, t } = useI18n()
 
   const loadPosts = useCallback(async () => {
     try {
@@ -57,7 +57,7 @@ export default function BlogPage() {
 
       const settings = getNostrSettings()
       if (!settings.ownerNpub) {
-        setError("No Nostr public key configured. Please update settings.json to add your npub.")
+        setError(t("home.no_npub"))
         return
       }
 
@@ -66,11 +66,11 @@ export default function BlogPage() {
       setFilteredPosts(postsData)
     } catch (err) {
       console.error("Error loading posts:", err)
-      setError("Failed to load posts. Please try again.")
+      setError(t("home.failed_load"))
     } finally {
       setLoading(false)
     }
-  }, [locale])
+  }, [locale, t])
 
   useEffect(() => {
     loadPosts()
@@ -120,9 +120,9 @@ export default function BlogPage() {
         <div className="container mx-auto px-4 py-8">
           <div className="mb-8">
             <h1 className="text-4xl font-bold mb-4 bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
-              Blog Posts
+              {t("blog.title")}
             </h1>
-            <p className="text-slate-600 dark:text-slate-300">All my thoughts, articles, and notes from Nostr</p>
+            <p className="text-slate-600 dark:text-slate-300">{t("blog.subtitle")}</p>
           </div>
 
           <div className="space-y-6">
@@ -156,7 +156,7 @@ export default function BlogPage() {
         <div className="container mx-auto px-4 py-8">
           <div className="mb-8">
             <h1 className="text-4xl font-bold mb-4 bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
-              Blog Posts
+              {t("blog.title")}
             </h1>
           </div>
 
@@ -166,7 +166,7 @@ export default function BlogPage() {
               <div className="flex gap-2">
                 <Button onClick={loadPosts} size="sm" variant="outline">
                   <RefreshCw className="h-4 w-4 mr-2" />
-                  Retry
+                  {t("home.retry")}
                 </Button>
               </div>
             </AlertDescription>
@@ -182,9 +182,9 @@ export default function BlogPage() {
         {/* Header */}
         <div className="mb-8">
           <h1 className="text-4xl font-bold mb-4 bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
-            Blog Posts
+            {t("blog.title")}
           </h1>
-          <p className="text-slate-600 dark:text-slate-300">All my thoughts, articles, and notes from Nostr</p>
+          <p className="text-slate-600 dark:text-slate-300">{t("blog.subtitle")}</p>
         </div>
 
         {/* Search and Filter */}
@@ -194,7 +194,7 @@ export default function BlogPage() {
               <div className="relative flex-1">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
                 <Input
-                  placeholder="Search posts..."
+                  placeholder={t("blog.search_placeholder")}
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   className="pl-10 border-0 bg-slate-100 dark:bg-slate-700"
@@ -209,7 +209,7 @@ export default function BlogPage() {
                     selectedType === "all" && "bg-slate-200 dark:bg-slate-700",
                   )}
                 >
-                  All ({posts.length})
+                  {t("blog.all")} ({posts.length})
                 </Button>
                 <Button
                   variant="outline"
@@ -221,7 +221,7 @@ export default function BlogPage() {
                   )}
                 >
                   <MessageSquare className="h-4 w-4 mr-2" />
-                  Notes ({posts.filter((p) => p.type === "note").length})
+                  {t("blog.notes")} ({posts.filter((p) => p.type === "note").length})
                 </Button>
                 <Button
                   variant="outline"
@@ -233,7 +233,7 @@ export default function BlogPage() {
                   )}
                 >
                   <FileText className="h-4 w-4 mr-2" />
-                  Articles ({posts.filter((p) => p.type === "article").length})
+                  {t("blog.articles")} ({posts.filter((p) => p.type === "article").length})
                 </Button>
               </div>
             </div>
@@ -247,7 +247,7 @@ export default function BlogPage() {
               <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
                 <CardContent className="p-8 text-center">
                   <p className="text-slate-600 dark:text-slate-300">
-                    {posts.length === 0 ? "No posts found." : "No posts match your search criteria."}
+                    {posts.length === 0 ? t("home.no_posts") : t("home.no_posts_match")}
                   </p>
                 </CardContent>
               </Card>
@@ -275,12 +275,12 @@ export default function BlogPage() {
                         {post.type === "article" ? (
                           <>
                             <FileText className="h-3 w-3 mr-1" />
-                          Article
+                          {t("blog.article")}
                         </>
                       ) : (
                         <>
                           <MessageSquare className="h-3 w-3 mr-1" />
-                          Note
+                          {t("blog.note")}
                         </>
                       )}
                       </Badge>

--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -1,12 +1,24 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
+import { cookies } from 'next/headers'
 import { marked } from 'marked'
 import { getNote } from '@/lib/digital-garden'
 import { Badge } from '@/components/ui/badge'
 import { slugify } from '@/lib/slugify'
+import en from '@/locales/en.json'
+import es from '@/locales/es.json'
+
+const translations = { en, es } as const
+
+function getT(locale: keyof typeof translations) {
+  return (key: string) =>
+    key.split('.').reduce((o: any, k) => (o ? o[k] : undefined), translations[locale]) || key
+}
 
 export default async function DigitalGardenNotePage({ params }: { params: { slug: string } }) {
-  const note = await getNote(params.slug)
+  const locale = (cookies().get('NEXT_LOCALE')?.value || 'en') as 'en' | 'es'
+  const t = getT(locale)
+  const note = await getNote(params.slug, locale)
   if (!note) {
     notFound()
   }
@@ -36,7 +48,7 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
       </article>
       <div className="mt-8">
         <Link href="/digital-garden" className="text-blue-600 hover:underline">
-          ← Back to Garden
+          {t('digital_garden.back')}
         </Link>
       </div>
     </div>

--- a/app/digital-garden/graph/page.tsx
+++ b/app/digital-garden/graph/page.tsx
@@ -1,12 +1,24 @@
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
+import { cookies } from 'next/headers'
 import { getAllNotes } from '@/lib/digital-garden'
 import { slugify } from '@/lib/slugify'
+import en from '@/locales/en.json'
+import es from '@/locales/es.json'
+
+const translations = { en, es } as const
+
+function getT(locale: keyof typeof translations) {
+  return (key: string) =>
+    key.split('.').reduce((o: any, k) => (o ? o[k] : undefined), translations[locale]) || key
+}
 
 const WikiGraph = dynamic(() => import('@/components/wiki-graph'), { ssr: false })
 
 export default async function DigitalGardenGraphPage() {
-  const notes = await getAllNotes()
+  const locale = (cookies().get('NEXT_LOCALE')?.value || 'en') as 'en' | 'es'
+  const t = getT(locale)
+  const notes = await getAllNotes(locale)
   const nodes = notes.map((n) => ({ id: n.slug, title: n.title }))
   const links: { source: string; target: string }[] = []
   const linkRegex = /\[\[([^\]]+)\]\]/g
@@ -21,11 +33,11 @@ export default async function DigitalGardenGraphPage() {
   }
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="mb-4 text-center text-3xl font-bold">Garden Graph</h1>
+      <h1 className="mb-4 text-center text-3xl font-bold">{t('digital_garden.garden_graph')}</h1>
       <WikiGraph data={{ nodes, links }} />
       <div className="mt-4 text-center">
         <Link href="/digital-garden" className="text-blue-600 hover:underline">
-          ← Back to Garden
+          {t('digital_garden.back')}
         </Link>
       </div>
     </div>

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { cookies } from 'next/headers'
 import { getAllNotes } from '@/lib/digital-garden'
 import { getSiteName } from '@/lib/settings'
 import {
@@ -9,13 +10,27 @@ import {
 } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
+import en from '@/locales/en.json'
+import es from '@/locales/es.json'
+
+const translations = { en, es } as const
+
+function getT(locale: keyof typeof translations) {
+  return (key: string) =>
+    key.split('.').reduce((o: any, k) => (o ? o[k] : undefined), translations[locale]) || key
+}
 
 export default async function DigitalGardenPage({
   searchParams,
 }: {
   searchParams: { tag?: string }
 }) {
-  const [notes, siteName] = await Promise.all([getAllNotes(), getSiteName()])
+  const locale = (cookies().get('NEXT_LOCALE')?.value || 'en') as 'en' | 'es'
+  const t = getT(locale)
+  const [notes, siteName] = await Promise.all([
+    getAllNotes(locale),
+    getSiteName(),
+  ])
   const allTags = Array.from(new Set(notes.flatMap((n) => n.tags))).sort()
   const activeTag = searchParams.tag
   const filteredNotes = activeTag
@@ -24,11 +39,11 @@ export default async function DigitalGardenPage({
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="mb-8 text-center text-4xl font-bold">
-        {siteName}&apos;s Garden
+        {siteName}&apos;s {t('navbar.garden')}
       </h1>
       <div className="mb-4 text-center">
         <Link href="/digital-garden/graph" className="text-blue-600 hover:underline">
-          Graph View
+          {t('digital_garden.graph_view')}
         </Link>
       </div>
       {allTags.length > 0 && (
@@ -41,7 +56,7 @@ export default async function DigitalGardenPage({
                 !activeTag && 'bg-green-500 text-white',
               )}
             >
-              All
+              {t('digital_garden.all')}
             </Badge>
           </Link>
           {allTags.map((tag) => (

--- a/locales/en.json
+++ b/locales/en.json
@@ -57,5 +57,21 @@
     "no_posts": "No posts found.",
     "no_posts_match": "No posts match your search criteria.",
     "anonymous": "Anonymous"
+  },
+  "blog": {
+    "title": "Blog Posts",
+    "subtitle": "All my thoughts, articles, and notes from Nostr",
+    "search_placeholder": "Search posts...",
+    "all": "All",
+    "notes": "Notes",
+    "articles": "Articles",
+    "article": "Article",
+    "note": "Note"
+  },
+  "digital_garden": {
+    "graph_view": "Graph View",
+    "all": "All",
+    "garden_graph": "Garden Graph",
+    "back": "\u2190 Back to Garden"
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -57,5 +57,21 @@
     "no_posts": "No se encontraron publicaciones.",
     "no_posts_match": "Ninguna publicación coincide con tu búsqueda.",
     "anonymous": "Anónimo"
+  },
+  "blog": {
+    "title": "Publicaciones del Blog",
+    "subtitle": "Todas mis ideas, artículos y notas de Nostr",
+    "search_placeholder": "Buscar publicaciones...",
+    "all": "Todos",
+    "notes": "Notas",
+    "articles": "Artículos",
+    "article": "Artículo",
+    "note": "Nota"
+  },
+  "digital_garden": {
+    "graph_view": "Vista de Grafo",
+    "all": "Todo",
+    "garden_graph": "Grafo del Jardín",
+    "back": "\u2190 Volver al Jardín"
   }
 }


### PR DESCRIPTION
## Summary
- Serve digital garden notes based on user's language cookie
- Localize digital garden pages and blog UI elements
- Add Spanish and English strings for blog and digital garden views

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688d82b6e9e0832684190a57257e2f4c