### PR TITLE
fix: load spanish nostr translations without 404

### DIFF
--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -400,16 +400,28 @@ export async function fetchNostrPost(
     }
 
     if (locale === "es") {
-      const baseUrl =
-        typeof window === "undefined"
-          ? process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
-          : ""
       try {
-        const res = await fetch(`${baseUrl}/api/nostr-translations/${eventId}`)
-        if (!res.ok) return null
-        const data = await res.json()
-        post.content = data.content
-        post.translation = data.data
+        if (typeof window === "undefined") {
+          const fs = await import("fs/promises")
+          const path = await import("path")
+          const matter = (await import("gray-matter")).default
+
+          const filePath = path.join(
+            process.cwd(),
+            "nostr-translations",
+            `${eventId}.md`,
+          )
+          const raw = await fs.readFile(filePath, "utf8")
+          const { data, content } = matter(raw)
+          post.content = content
+          post.translation = data
+        } else {
+          const res = await fetch(`/api/nostr-translations/${eventId}`)
+          if (!res.ok) return null
+          const data = await res.json()
+          post.content = data.content
+          post.translation = data.data
+        }
       } catch {
         return null
       }


### PR DESCRIPTION
## Summary
- avoid 404 when opening spanish nostr posts by reading translation files on the server

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688d858f054c832687a252a44517b28e