### PR TITLE
Fix Spanish Nostr translation routing

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -256,7 +256,11 @@ export default function BlogPage() {
             filteredPosts.map((post) => (
               <Link
                 key={post.id}
-                href={`/blog/${post.id}`}
+                href={
+                  locale === "es"
+                    ? `/es/${post.id}`
+                    : `/blog/${post.id}`
+                }
                 className="group block"
               >
                 <Card

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -328,7 +328,9 @@ export default function HomePage() {
                 href={
                   post.type === "garden"
                     ? `/digital-garden/${post.id}`
-                    : `/blog/${post.id}`
+                    : locale === "es"
+                      ? `/es/${post.id}`
+                      : `/blog/${post.id}`
                 }
                 className="group block"
               >


### PR DESCRIPTION
## Summary
- ensure Spanish Nostr posts link to translated route under `/es/[id]`
- update homepage and blog listing to build locale-aware links

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688d8880294c832684b1f41f22a535b2