### PR TITLE
Route Spanish translations to localized posts

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -256,7 +256,7 @@ export default function BlogPage() {
             filteredPosts.map((post) => (
               <Link
                 key={post.id}
-                href={`/blog/${post.id}`}
+                href={locale === "es" ? `/es/${post.id}` : `/blog/${post.id}`}
                 className="group block"
               >
                 <Card

--- a/app/es/[id]/page.tsx
+++ b/app/es/[id]/page.tsx
@@ -1,0 +1,1 @@
+export { default, generateMetadata, generateStaticParams } from "../../blog/[id]/page";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -328,6 +328,8 @@ export default function HomePage() {
                 href={
                   post.type === "garden"
                     ? `/digital-garden/${post.id}`
+                    : locale === "es"
+                    ? `/es/${post.id}`
                     : `/blog/${post.id}`
                 }
                 className="group block"

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { searchContent, SearchSource } from '@/lib/search'
+import { cookies } from 'next/headers'
 
 export default async function SearchPage({
   searchParams,
@@ -8,7 +9,9 @@ export default async function SearchPage({
 }) {
   const query = searchParams.q ?? ''
   const source = searchParams.source as SearchSource | undefined
-  const results = await searchContent(query, source)
+  const cookieStore = cookies()
+  const locale = (cookieStore.get('NEXT_LOCALE')?.value as 'en' | 'es') || 'en'
+  const results = await searchContent(query, source, locale)
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -13,7 +13,11 @@ export interface SearchResult {
   snippet: string
 }
 
-export async function searchContent(query: string, source?: SearchSource): Promise<SearchResult[]> {
+export async function searchContent(
+  query: string,
+  source?: SearchSource,
+  locale: 'en' | 'es' = 'en'
+): Promise<SearchResult[]> {
   const q = query.toLowerCase()
   const results: SearchResult[] = []
 
@@ -24,7 +28,11 @@ export async function searchContent(query: string, source?: SearchSource): Promi
 
   if (includeNostr && settings.ownerNpub) {
     try {
-      const posts = await fetchNostrPosts(settings.ownerNpub, settings.maxPosts)
+      const posts = await fetchNostrPosts(
+        settings.ownerNpub,
+        settings.maxPosts,
+        locale
+      )
       for (const post of posts) {
         const postType: SearchSource = post.type === 'article' ? 'article' : 'nostr'
         if (source && source !== postType) continue
@@ -32,8 +40,15 @@ export async function searchContent(query: string, source?: SearchSource): Promi
         if (!q || text.includes(q)) {
           results.push({
             type: postType,
-            title: post.title || (post.content.length > 60 ? post.content.slice(0, 60) + '…' : post.content),
-            url: `/blog/${post.id}`,
+            title:
+              post.title ||
+              (post.content.length > 60
+                ? post.content.slice(0, 60) + '…'
+                : post.content),
+            url:
+              locale === 'es'
+                ? `/es/${post.id}`
+                : `/blog/${post.id}`,
             snippet: post.summary || post.content.slice(0, 200),
           })
         }


### PR DESCRIPTION
## Summary
- add /es/[id] route that reuses blog post page for Spanish content
- link to localized posts when browsing in Spanish
- include locale-aware URLs in search results

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d8880294c832684b1f41f22a535b2