### PR TITLE
Add bilingual digital garden notes

### DIFF
--- a/digital-garden/en/austrian-economics.md
+++ b/digital-garden/en/austrian-economics.md
@@ -1,7 +1,0 @@
----
-title: Austrian Economics
-date: 2025-07-31
-tags: [economics]
----
-
-Austrian Economics focuses on individual choice and market processes, ideas that inspire approaches in [[Biohacking]], [[Fitness]], [[Mindset]], and developments in [[Tech]].

--- a/digital-garden/en/biohacking.md
+++ b/digital-garden/en/biohacking.md
@@ -1,7 +1,0 @@
----
-title: Biohacking
-date: 2025-07-31
-tags: [biohacking]
----
-
-Biohacking blends [[Fitness]], [[Mindset]], and [[Tech]] to optimize the body and mind, shaped by incentives highlighted in [[Austrian Economics]].

--- a/digital-garden/en/decentralized-pedagogy.md
+++ b/digital-garden/en/decentralized-pedagogy.md
@@ -1,0 +1,9 @@
+---
+title: Decentralized Pedagogy
+date: 2025-08-02
+tags: [education]
+---
+
+Teach Bitcoin and sovereignty without traditional institutions. Use memes, decisions, and open tools to create self-directed learning.
+
+📎 [[Bitcoin Education]] · [[WeAreBitcoin]] · [[Deschooling]]

--- a/digital-garden/en/fiat-as-distraction.md
+++ b/digital-garden/en/fiat-as-distraction.md
@@ -1,0 +1,9 @@
+---
+title: Fiat as Distraction
+date: 2025-08-02
+tags: [economics]
+---
+
+The fiat system not only devalues money. It also fragments attention with short-term incentives. It affects [[Productivity]], [[Purpose]], and decision-making.
+
+📎 [[Fiat is the Enemy]] · [[Austrian Economics]] · [[Cognitive Minimalism]]

--- a/digital-garden/en/financial-sovereignty.md
+++ b/digital-garden/en/financial-sovereignty.md
@@ -1,0 +1,9 @@
+---
+title: Financial Sovereignty
+date: 2025-08-02
+tags: [finance]
+---
+
+Ability to control your wealth without relying on banks or governments. Achieved with hard money like [[Bitcoin]], your own keys, and personal custody.
+
+📎 [[Personal Decentralization]] · [[Fiat is the Enemy]] · [[Key Ownership]]

--- a/digital-garden/en/fitness.md
+++ b/digital-garden/en/fitness.md
@@ -1,7 +1,0 @@
----
-title: Fitness
-date: 2025-07-31
-tags: [health]
----
-
-Fitness supports [[Biohacking]] and depends on a growth-oriented [[Mindset]]; wearables and apps in [[Tech]] track progress, and the self-ownership ideas in [[Austrian Economics]] encourage personal accountability.

--- a/digital-garden/en/high-performance-tools.md
+++ b/digital-garden/en/high-performance-tools.md
@@ -1,0 +1,9 @@
+---
+title: High-Performance Tools
+date: 2025-08-02
+tags: [technology]
+---
+
+Apps, automations, and systems that optimize energy, focus, and decision-making. Key: remove friction and increase clarity.
+
+📎 [[Technology]] · [[Personal Systems]] · [[Mind Hacking]]

--- a/digital-garden/en/intermittent-fasting.md
+++ b/digital-garden/en/intermittent-fasting.md
@@ -1,0 +1,9 @@
+---
+title: Intermittent Fasting
+date: 2025-08-02
+tags: [health]
+---
+
+Practice of eating within specific time windows. Improves insulin sensitivity, mental clarity, and energy. Ideal complement to [[Biohacking]].
+
+📎 [[Flexible Metabolism]] · [[Carnivore Diet]] · [[Ancestral Health]]

--- a/digital-garden/en/key-ownership.md
+++ b/digital-garden/en/key-ownership.md
@@ -1,0 +1,9 @@
+---
+title: Key Ownership
+date: 2025-08-02
+tags: [security]
+---
+
+If you don't control your private keys, you don't control your data or your money. Applies to [[Bitcoin]], email, identity, and personal notes.
+
+📎 [[Financial Sovereignty]] · [[Digital Autonomy]] · [[Personal Cryptography]]

--- a/digital-garden/en/mindset.md
+++ b/digital-garden/en/mindset.md
@@ -1,7 +1,0 @@
----
-title: Mindset
-date: 2025-07-31
-tags: [psychology]
----
-
-A resilient mindset fuels [[Fitness]] goals, enables adventurous [[Biohacking]], interprets markets through [[Austrian Economics]], and adapts to evolving [[Tech]].

--- a/digital-garden/en/minimum-effective-training.md
+++ b/digital-garden/en/minimum-effective-training.md
@@ -1,0 +1,9 @@
+---
+title: Minimum Effective Training
+date: 2025-08-02
+tags: [fitness]
+---
+
+Short, consistent, high-impact physical routine. Focused on [[Calisthenics]], [[Sprints]], and [[Mobility]]. Ideal for maintaining energy and longevity.
+
+📎 [[Fitness]] · [[Physical Biohacking]] · [[Frictionless Discipline]]

--- a/digital-garden/en/publish-without-platforms.md
+++ b/digital-garden/en/publish-without-platforms.md
@@ -1,0 +1,9 @@
+---
+title: Publish Without Platforms
+date: 2025-08-02
+tags: [writing]
+---
+
+Writing online without relying on Substack or Medium. Use open tools like [[Nostr]], [[Next.js]], or Git to control content.
+
+📎 [[Personal Decentralization]] · [[Sovereign Technology]] · [[Digital Identity]]

--- a/digital-garden/en/systems-vs-willpower.md
+++ b/digital-garden/en/systems-vs-willpower.md
@@ -1,0 +1,9 @@
+---
+title: Systems vs Willpower
+date: 2025-08-02
+tags: [productivity]
+---
+
+Motivation is volatile. Consistent systems (reminders, automation, habits) sustain progress without relying on emotional state.
+
+📎 [[Smart Habits]] · [[Automation with Bots]] · [[Mind Hacking]]

--- a/digital-garden/en/tech.md
+++ b/digital-garden/en/tech.md
@@ -1,7 +1,0 @@
----
-title: Tech
-date: 2025-07-31
-tags: [technology]
----
-
-Tech tools—from wearables to digital economies informed by [[Austrian Economics]]—support [[Biohacking]], enhance [[Fitness]], and shape modern [[Mindset]] practices.

--- a/digital-garden/es/austrian-economics.md
+++ b/digital-garden/es/austrian-economics.md
@@ -1,7 +1,0 @@
----
-title: Economía Austriaca
-date: 2025-07-31
-tags: [economía]
----
-
-La Economía Austriaca se enfoca en la elección individual y los procesos de mercado, ideas que inspiran enfoques en [[Biohacking]], [[Fitness]], [[Mindset]] y desarrollos en [[Tech]].

--- a/digital-garden/es/biohacking.md
+++ b/digital-garden/es/biohacking.md
@@ -1,7 +1,0 @@
----
-title: Biohacking
-date: 2025-07-31
-tags: [biohacking]
----
-
-El Biohacking combina [[Fitness]], [[Mindset]] y [[Tech]] para optimizar el cuerpo y la mente, moldeado por los incentivos destacados en [[Austrian Economics]].

--- a/digital-garden/es/decentralized-pedagogy.md
+++ b/digital-garden/es/decentralized-pedagogy.md
@@ -1,0 +1,9 @@
+---
+title: Pedagogía Descentralizada
+date: 2025-08-02
+tags: [educacion]
+---
+
+Enseñar Bitcoin y soberanía sin instituciones tradicionales. Usar memes, decisiones, y herramientas libres para crear aprendizaje autodirigido.
+
+📎 [[Bitcoin Education]] · [[WeAreBitcoin]] · [[Deschooling]]

--- a/digital-garden/es/fiat-as-distraction.md
+++ b/digital-garden/es/fiat-as-distraction.md
@@ -1,0 +1,9 @@
+---
+title: Fiat como Distracción
+date: 2025-08-02
+tags: [economía]
+---
+
+El sistema fiat no solo devalúa el dinero. También fragmenta la atención con incentivos de corto plazo. Afecta la [[Productividad]], el [[Propósito]] y la toma de decisiones.
+
+📎 [[Fiat is the Enemy]] · [[Austrian Economics]] · [[Cognitive Minimalism]]

--- a/digital-garden/es/financial-sovereignty.md
+++ b/digital-garden/es/financial-sovereignty.md
@@ -1,0 +1,9 @@
+---
+title: Soberanía Financiera
+date: 2025-08-02
+tags: [finanzas]
+---
+
+Capacidad de controlar tu riqueza sin depender de bancos ni gobiernos. Se logra con dinero duro como [[Bitcoin]], claves propias y custodia personal.
+
+📎 [[Personal Decentralization]] · [[Fiat is the Enemy]] · [[Key Ownership]]

--- a/digital-garden/es/fitness.md
+++ b/digital-garden/es/fitness.md
@@ -1,7 +1,0 @@
----
-title: Fitness
-date: 2025-07-31
-tags: [salud]
----
-
-El Fitness apoya el [[Biohacking]] y depende de un [[Mindset]] orientado al crecimiento; los dispositivos y aplicaciones en [[Tech]] registran el progreso, y las ideas de propiedad propia en [[Austrian Economics]] fomentan la responsabilidad personal.

--- a/digital-garden/es/high-performance-tools.md
+++ b/digital-garden/es/high-performance-tools.md
@@ -1,0 +1,9 @@
+---
+title: Herramientas para el Alto Rendimiento
+date: 2025-08-02
+tags: [tecnologia]
+---
+
+Apps, automatizaciones y sistemas que optimizan energía, foco y toma de decisiones. Clave: eliminar fricción y aumentar claridad.
+
+📎 [[Technology]] · [[Personal Systems]] · [[Mind Hacking]]

--- a/digital-garden/es/intermittent-fasting.md
+++ b/digital-garden/es/intermittent-fasting.md
@@ -1,0 +1,9 @@
+---
+title: Ayuno Intermitente
+date: 2025-08-02
+tags: [salud]
+---
+
+Práctica de comer en ventanas de tiempo específicas. Mejora sensibilidad a la insulina, claridad mental y energía. Complemento ideal para el [[Biohacking]].
+
+📎 [[Flexible Metabolism]] · [[Carnivore Diet]] · [[Ancestral Health]]

--- a/digital-garden/es/key-ownership.md
+++ b/digital-garden/es/key-ownership.md
@@ -1,0 +1,9 @@
+---
+title: Propiedad de claves
+date: 2025-08-02
+tags: [seguridad]
+---
+
+Si no controlás tus claves privadas, no controlás tus datos ni tu dinero. Aplicable a [[Bitcoin]], correos, identidad y notas personales.
+
+📎 [[Financial Sovereignty]] · [[Digital Autonomy]] · [[Personal Cryptography]]

--- a/digital-garden/es/mindset.md
+++ b/digital-garden/es/mindset.md
@@ -1,7 +1,0 @@
----
-title: Mentalidad
-date: 2025-07-31
-tags: [psicología]
----
-
-Una mentalidad resiliente impulsa las metas de [[Fitness]], habilita un [[Biohacking]] aventurero, interpreta los mercados mediante [[Austrian Economics]] y se adapta a la [[Tech]] en evolución.

--- a/digital-garden/es/minimum-effective-training.md
+++ b/digital-garden/es/minimum-effective-training.md
@@ -1,0 +1,9 @@
+---
+title: Entrenamiento Mínimo Efectivo
+date: 2025-08-02
+tags: [salud]
+---
+
+Rutina física corta, consistente y con alto impacto. Enfocada en [[Calistenia]], [[Sprints]] y [[Movilidad]]. Ideal para mantener energía y longevidad.
+
+📎 [[Fitness]] · [[Physical Biohacking]] · [[Frictionless Discipline]]

--- a/digital-garden/es/publish-without-platforms.md
+++ b/digital-garden/es/publish-without-platforms.md
@@ -1,0 +1,9 @@
+---
+title: Publicar sin plataformas
+date: 2025-08-02
+tags: [escritura]
+---
+
+Escribir online sin depender de Substack o Medium. Usar herramientas abiertas como [[Nostr]], [[Next.js]] o Git para tener control del contenido.
+
+📎 [[Personal Decentralization]] · [[Sovereign Technology]] · [[Digital Identity]]

--- a/digital-garden/es/systems-vs-willpower.md
+++ b/digital-garden/es/systems-vs-willpower.md
@@ -1,0 +1,9 @@
+---
+title: Sistema vs Fuerza de Voluntad
+date: 2025-08-02
+tags: [productividad]
+---
+
+La motivación es volátil. Los sistemas consistentes (recordatorios, automatización, hábitos) sostienen el progreso sin depender del estado emocional.
+
+📎 [[Smart Habits]] · [[Automation with Bots]] · [[Mind Hacking]]

--- a/digital-garden/es/tech.md
+++ b/digital-garden/es/tech.md
@@ -1,7 +1,0 @@
----
-title: Tecnología
-date: 2025-07-31
-tags: [tecnología]
----
-
-Las herramientas de [[Tech]]—desde dispositivos portátiles hasta economías digitales informadas por [[Austrian Economics]]—apoyan el [[Biohacking]], mejoran el [[Fitness]] y moldean las prácticas modernas de [[Mindset]].


### PR DESCRIPTION
## Summary
- remove temporary test notes from digital garden
- add nine English and Spanish markdown notes with YAML front matter

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688d89af2f648326a6fbba2d435305c2