### PR TITLE
Show manual translations for Spanish Nostr posts

### DIFF
--- a/app/api/nostr-translations/[id]/route.ts
+++ b/app/api/nostr-translations/[id]/route.ts
@@ -10,11 +10,17 @@ export async function GET(
 ) {
   try {
     let id = params.id;
-    if (id.startsWith("note")) {
+    if (id.startsWith("note") || id.startsWith("nevent")) {
       try {
         const decoded = nip19.decode(id);
         if (decoded.type === "note") {
           id = decoded.data as string;
+        } else if (decoded.type === "nevent") {
+          if (typeof decoded.data === "string") {
+            id = decoded.data as string;
+          } else if (decoded.data && typeof decoded.data === "object") {
+            id = (decoded.data as any).id as string;
+          }
         }
       } catch {
         // ignore decode errors and try as-is

--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -11,16 +11,8 @@ import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
 import { nip19 } from "nostr-tools"
 
-export async function generateStaticParams() {
-  const settings = getNostrSettings()
-  if (!settings.ownerNpub) return []
-  try {
-    const posts = await nostrClient.fetchPosts(settings.ownerNpub, settings.maxPosts || 50)
-    return posts.map((post) => ({ id: post.id }))
-  } catch {
-    return []
-  }
-}
+export const dynamic = "force-dynamic"
+export const revalidate = 0
 
 export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"


### PR DESCRIPTION
## Summary
- replace English fallback with manual Spanish translations for Nostr posts
- decode `note` or `nevent` IDs when loading translations

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688d8e4fbfd483268d2abe750e67ce19