### PR TITLE
Add Spanish profile description translation

### DIFF
--- a/nostr-translations/d9590d95a7811e1cb312be66edd664d7e3e6ed57822ad9f213ed620fc6748be8.md
+++ b/nostr-translations/d9590d95a7811e1cb312be66edd664d7e3e6ed57822ad9f213ed620fc6748be8.md
@@ -1,0 +1,7 @@
+---
+lang: es
+publishing_date: 2025-08-02
+type: profile
+kind: 0
+---
+Desarrollador y entusiasta de Nostr que comparte artículos y proyectos en este blog personal.

--- a/public/es/nostr/d9590d95a7811e1cb312be66edd664d7e3e6ed57822ad9f213ed620fc6748be8.md
+++ b/public/es/nostr/d9590d95a7811e1cb312be66edd664d7e3e6ed57822ad9f213ed620fc6748be8.md
@@ -1,0 +1,7 @@
+---
+lang: es
+publishing_date: 2025-08-02
+type: profile
+kind: 0
+---
+Desarrollador y entusiasta de Nostr que comparte artículos y proyectos en este blog personal.


### PR DESCRIPTION
## Summary
- Add Spanish translation for profile description in manual Nostr translations
- Include translation file in public directory for Spanish locale

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688d8e9fff408326b2a1e278f7bfe98c