### PR TITLE
feat: override nostr profile bio for spanish locale

### DIFF
--- a/app/api/nostr-profile/description/route.ts
+++ b/app/api/nostr-profile/description/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import path from "path";
+import { promises as fs } from "fs";
+
+export async function GET() {
+  try {
+    const filePath = path.join(process.cwd(), "nostr-translations", "es", "description.md");
+    const content = await fs.readFile(filePath, "utf8");
+    return new NextResponse(content, {
+      status: 200,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  } catch {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,7 +74,7 @@ export default function HomePage() {
 
       // Fetch profile, nostr posts, and garden notes
       const [profileData, nostrData, gardenData] = await Promise.all([
-        fetchNostrProfile(settings.ownerNpub),
+        fetchNostrProfile(settings.ownerNpub, locale),
         fetchNostrPosts(settings.ownerNpub, settings.maxPosts, locale),
         fetch("/api/digital-garden").then((res) => res.json()),
       ])

--- a/lib/nostr-profile.ts
+++ b/lib/nostr-profile.ts
@@ -11,8 +11,11 @@ const NOSTR_RELAYS = [
   "wss://relay.nostr.info",
 ]
 
-export async function fetchNostrProfile(npub: string): Promise<NostrProfile | null> {
-  return nostrClient.fetchNostrProfile(npub)
+export async function fetchNostrProfile(
+  npub: string,
+  locale = "en",
+): Promise<NostrProfile | null> {
+  return nostrClient.fetchProfile(npub, locale)
 }
 
 async function fetchProfileFromRelays(hexPubkey: string): Promise<NostrProfile | null> {

--- a/nostr-translations/es/description.md
+++ b/nostr-translations/es/description.md
@@ -1,0 +1,1 @@
+Esta es la descripción del perfil traducida manualmente al español.


### PR DESCRIPTION
## Summary
- serve Spanish profile bio from `nostr-translations/es/description.md`
- load translated bio when `fetchNostrProfile` is called with `es`
- request profile translation on the home page when locale is Spanish

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688d90c3cdcc832690a6eca4380e2296