### PR TITLE
Redirect Spanish previews to translations

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -256,7 +256,8 @@ export default function BlogPage() {
             filteredPosts.map((post) => (
               <Link
                 key={post.id}
-                href={`/blog/${post.id}`}
+                href={`/blog/${post.id}${locale === "es" ? "?lang=es" : ""}`}
+                prefetch={false}
                 className="group block"
               >
                 <Card

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -328,8 +328,9 @@ export default function HomePage() {
                 href={
                   post.type === "garden"
                     ? `/digital-garden/${post.id}`
-                    : `/blog/${post.id}`
+                    : `/blog/${post.id}${locale === "es" ? "?lang=es" : ""}`
                 }
+                prefetch={false}
                 className="group block"
               >
                 <Card


### PR DESCRIPTION
## Summary
- redirect Spanish users to translated nostr notes
- pass locale in blog links and disable prefetch to avoid stale language

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to store in localStorage: ReferenceError: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688dfd358d988326a22b3934200fe7e4