### PR TITLE
Redirect Spanish previews to translated notes

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -22,12 +22,19 @@ export async function generateStaticParams() {
   }
 }
 
-export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+export async function generateMetadata(
+  {
+    params,
+    searchParams,
+  }: { params: { id: string }; searchParams: { lang?: string } },
+): Promise<Metadata> {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"
   try {
     const cookieStore = cookies()
     const locale =
-      (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es") || "en"
+      (searchParams.lang as "en" | "es") ||
+      (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es") ||
+      "en"
     const post = await nostrClient.fetchPost(params.id, locale)
     if (!post) {
       return { title: "Post not found" }
@@ -51,12 +58,19 @@ export async function generateMetadata({ params }: { params: { id: string } }): 
   }
 }
 
-export default async function BlogPostPage({ params }: { params: { id: string } }) {
+export default async function BlogPostPage(
+  {
+    params,
+    searchParams,
+  }: { params: { id: string }; searchParams: { lang?: string } },
+) {
   const { id } = params
   const settings = getNostrSettings()
   const cookieStore = cookies()
   const locale =
-    (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es") || "en"
+    (searchParams.lang as "en" | "es") ||
+    (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es") ||
+    "en"
 
   if (!settings.ownerNpub || !settings.ownerNpub.startsWith("npub1")) {
     return (

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -256,7 +256,11 @@ export default function BlogPage() {
             filteredPosts.map((post) => (
               <Link
                 key={post.id}
-                href={`/blog/${post.id}`}
+                href={
+                  locale === 'es'
+                    ? `/blog/${post.id}?lang=es`
+                    : `/blog/${post.id}`
+                }
                 className="group block"
               >
                 <Card

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -328,6 +328,8 @@ export default function HomePage() {
                 href={
                   post.type === "garden"
                     ? `/digital-garden/${post.id}`
+                    : locale === 'es'
+                    ? `/blog/${post.id}?lang=es`
                     : `/blog/${post.id}`
                 }
                 className="group block"


### PR DESCRIPTION
## Summary
- honor `lang` query parameter to load translated Nostr posts
- link Spanish previews to `?lang=es` so translated note is opened

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688dfd358d988326a22b3934200fe7e4