### PR TITLE
feat: support lang query for blog posts

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -22,12 +22,22 @@ export async function generateStaticParams() {
   }
 }
 
-export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+  searchParams,
+}: {
+  params: { id: string }
+  searchParams: { lang?: string }
+}): Promise<Metadata> {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"
   try {
     const cookieStore = cookies()
     const locale =
-      (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es") || "en"
+      (searchParams.lang === "es" || searchParams.lang === "en"
+        ? searchParams.lang
+        : undefined) ||
+      (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es") ||
+      "en"
     const post = await nostrClient.fetchPost(params.id, locale)
     if (!post) {
       return { title: "Post not found" }
@@ -51,12 +61,22 @@ export async function generateMetadata({ params }: { params: { id: string } }): 
   }
 }
 
-export default async function BlogPostPage({ params }: { params: { id: string } }) {
+export default async function BlogPostPage({
+  params,
+  searchParams,
+}: {
+  params: { id: string }
+  searchParams: { lang?: string }
+}) {
   const { id } = params
   const settings = getNostrSettings()
   const cookieStore = cookies()
   const locale =
-    (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es") || "en"
+    (searchParams.lang === "es" || searchParams.lang === "en"
+      ? searchParams.lang
+      : undefined) ||
+    (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es") ||
+    "en"
 
   if (!settings.ownerNpub || !settings.ownerNpub.startsWith("npub1")) {
     return (


### PR DESCRIPTION
## Summary
- allow blog posts to load locale from `lang` query parameter
- fetch translated Nostr content when `lang` is provided

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688e009ef31483268d74672b2d0ae4c7