### PR TITLE
fix: read nostr translations from public locale folders

### DIFF
--- a/app/api/nostr-profile/description/route.ts
+++ b/app/api/nostr-profile/description/route.ts
@@ -4,7 +4,13 @@ import { promises as fs } from "fs";
 
 export async function GET() {
   try {
-    const filePath = path.join(process.cwd(), "nostr-translations", "es", "description.md");
+    const filePath = path.join(
+      process.cwd(),
+      "public",
+      "es",
+      "nostr",
+      "description.md",
+    );
     const content = await fs.readFile(filePath, "utf8");
     return new NextResponse(content, {
       status: 200,

--- a/app/api/nostr-translations/[id]/route.ts
+++ b/app/api/nostr-translations/[id]/route.ts
@@ -21,7 +21,13 @@ export async function GET(
       }
     }
 
-    const filePath = path.join(process.cwd(), "nostr-translations", `${id}.md`);
+    const filePath = path.join(
+      process.cwd(),
+      "public",
+      "es",
+      "nostr",
+      `${id}.md`,
+    );
     const raw = await fs.readFile(filePath, "utf8");
     const { data, content } = matter(raw);
     return NextResponse.json({ data, content });

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -168,8 +168,9 @@ export async function fetchNostrProfile(
           const path = await import("path")
           const filePath = path.join(
             process.cwd(),
-            "nostr-translations",
+            "public",
             "es",
+            "nostr",
             "description.md",
           )
           profile.about = (await fs.readFile(filePath, "utf8")).trim()
@@ -314,8 +315,10 @@ export async function fetchNostrPosts(
               const matter = (await import("gray-matter")).default
               const filePath = path.join(
                 process.cwd(),
-                "nostr-translations",
-                `${post.id}.md`
+                "public",
+                "es",
+                "nostr",
+                `${post.id}.md`,
               )
               const raw = await fs.readFile(filePath, "utf8")
               const { data, content } = matter(raw)
@@ -451,8 +454,10 @@ export async function fetchNostrPost(
           const matter = (await import("gray-matter")).default
           const filePath = path.join(
             process.cwd(),
-            "nostr-translations",
-            `${eventId}.md`
+            "public",
+            "es",
+            "nostr",
+            `${eventId}.md`,
           )
           const raw = await fs.readFile(filePath, "utf8")
           const { data, content } = matter(raw)


### PR DESCRIPTION
## Summary
- load Spanish Nostr profile description from `public/es/nostr`
- read Nostr event translations from `public/es/nostr`
- adjust API routes to serve translations from new public directories

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688e0352a5f083268f79e3e79c7d337e