### PR TITLE
Use public locale folders for Nostr translations

### DIFF
--- a/app/api/nostr-profile/description/route.ts
+++ b/app/api/nostr-profile/description/route.ts
@@ -2,9 +2,17 @@ import { NextResponse } from "next/server";
 import path from "path";
 import { promises as fs } from "fs";
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const filePath = path.join(process.cwd(), "nostr-translations", "es", "description.md");
+    const { searchParams } = new URL(request.url);
+    const locale = searchParams.get("locale") || "en";
+    const filePath = path.join(
+      process.cwd(),
+      "public",
+      locale,
+      "nostr",
+      "description.md"
+    );
     const content = await fs.readFile(filePath, "utf8");
     return new NextResponse(content, {
       status: 200,

--- a/app/api/nostr-translations/[id]/route.ts
+++ b/app/api/nostr-translations/[id]/route.ts
@@ -21,7 +21,15 @@ export async function GET(
       }
     }
 
-    const filePath = path.join(process.cwd(), "nostr-translations", `${id}.md`);
+    const { searchParams } = new URL(request.url);
+    const locale = searchParams.get("locale") || "en";
+    const filePath = path.join(
+      process.cwd(),
+      "public",
+      locale,
+      "nostr",
+      `${id}.md`
+    );
     const raw = await fs.readFile(filePath, "utf8");
     const { data, content } = matter(raw);
     return NextResponse.json({ data, content });

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -168,13 +168,14 @@ export async function fetchNostrProfile(
           const path = await import("path")
           const filePath = path.join(
             process.cwd(),
-            "nostr-translations",
-            "es",
+            "public",
+            locale,
+            "nostr",
             "description.md",
           )
           profile.about = (await fs.readFile(filePath, "utf8")).trim()
         } else {
-          const res = await fetch("/api/nostr-profile/description")
+          const res = await fetch(`/api/nostr-profile/description?locale=${locale}`)
           if (res.ok) {
             profile.about = (await res.text()).trim()
           }
@@ -314,7 +315,9 @@ export async function fetchNostrPosts(
               const matter = (await import("gray-matter")).default
               const filePath = path.join(
                 process.cwd(),
-                "nostr-translations",
+                "public",
+                locale,
+                "nostr",
                 `${post.id}.md`
               )
               const raw = await fs.readFile(filePath, "utf8")
@@ -323,7 +326,7 @@ export async function fetchNostrPosts(
               post.translation = data
               translated.push(post)
             } else {
-              const res = await fetch(`/api/nostr-translations/${post.id}`)
+              const res = await fetch(`/api/nostr-translations/${post.id}?locale=${locale}`)
               if (!res.ok) return
               const data = await res.json()
               post.content = data.content
@@ -451,7 +454,9 @@ export async function fetchNostrPost(
           const matter = (await import("gray-matter")).default
           const filePath = path.join(
             process.cwd(),
-            "nostr-translations",
+            "public",
+            locale,
+            "nostr",
             `${eventId}.md`
           )
           const raw = await fs.readFile(filePath, "utf8")
@@ -459,7 +464,7 @@ export async function fetchNostrPost(
           post.content = content
           post.translation = data
         } else {
-          const res = await fetch(`/api/nostr-translations/${eventId}`)
+          const res = await fetch(`/api/nostr-translations/${eventId}?locale=${locale}`)
           if (res.ok) {
             const data = await res.json()
             post.content = data.content


### PR DESCRIPTION
## Summary
- read Nostr profile and event translations from `public/<locale>/nostr`
- allow translation APIs to select language via `locale` query parameter

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688e0352a5f083268f79e3e79c7d337e