### PR TITLE
feat: load digital garden notes from locale public folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a personal blog website built with Next.js, Tailwind CSS, and Shadcn UI.
 
 - **Nostr Integration** – Fetches NIP‑23 long‑form articles and NIP‑01 notes from the relays listed in `settings.json`. Profile information is also pulled from Nostr and cached locally.
 - **Blog** – Lists your posts with search and type filters. Each post has its own page with Markdown rendering and optional tags.
-- **Digital Garden** – Markdown notes in `digital-garden/` are rendered with `[[wikilink]]` style linking between pages.
+- **Digital Garden** – Markdown notes in `public/en/digital-garden` and `public/es/digital-garden` are rendered with `[[wikilink]]` style linking between pages.
 - **Lifestyle Page** – Shows posts tagged `#lifestyle` from Nostr alongside configurable lists of workouts, nutrition, biohacks and routines.
 - **Contact Form** – Sends an encrypted direct message via Nostr to the owner npub.
 - **Portfolio & Resume** – Dedicated pages to showcase projects and display a résumé/CV.

--- a/lib/digital-garden.ts
+++ b/lib/digital-garden.ts
@@ -10,10 +10,15 @@ export interface DigitalGardenNote {
   content: string
 }
 
-const baseDir = path.join(process.cwd(), 'digital-garden')
+// Notes are stored in the public folder under locale-specific directories:
+//   public/en/digital-garden
+//   public/es/digital-garden
+// Using the public folder allows the same markdown files to be served
+// statically while also being accessible via the filesystem for parsing.
+const baseDir = path.join(process.cwd(), 'public')
 
 export async function getAllNotes(locale: string = 'en'): Promise<DigitalGardenNote[]> {
-  const notesDir = path.join(baseDir, locale)
+  const notesDir = path.join(baseDir, locale, 'digital-garden')
   const files = await fs.readdir(notesDir)
   const notes: DigitalGardenNote[] = []
   for (const file of files) {
@@ -38,7 +43,7 @@ export async function getNote(
   slug: string,
   locale: string = 'en'
 ): Promise<{ title: string; tags: string[]; content: string } | null> {
-  const filePath = path.join(baseDir, locale, `${slug}.md`)
+  const filePath = path.join(baseDir, locale, 'digital-garden', `${slug}.md`)
   try {
     const content = await fs.readFile(filePath, 'utf8')
     const { data, content: body } = matter(content)

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -44,27 +44,32 @@ export async function searchContent(query: string, source?: SearchSource): Promi
   }
 
   if (includeGarden) {
-    const notesDir = path.join(process.cwd(), 'digital-garden')
-    try {
-      const files = await fs.readdir(notesDir)
-      for (const file of files) {
-        if (!file.endsWith('.md')) continue
-        const slug = file.replace(/\.md$/, '')
-        const raw = await fs.readFile(path.join(notesDir, file), 'utf8')
-        const { data, content } = matter(raw)
-        const title = (data as any).title || slug
-        const text = `${title} ${content}`.toLowerCase()
-        if (!q || text.includes(q)) {
-          results.push({
-            type: 'garden',
-            title,
-            url: `/digital-garden/${slug}`,
-            snippet: content.slice(0, 200),
-          })
+    // Search through both English and Spanish digital garden notes stored in
+    // public/en/digital-garden and public/es/digital-garden.
+    const locales = ['en', 'es']
+    for (const locale of locales) {
+      const notesDir = path.join(process.cwd(), 'public', locale, 'digital-garden')
+      try {
+        const files = await fs.readdir(notesDir)
+        for (const file of files) {
+          if (!file.endsWith('.md')) continue
+          const slug = file.replace(/\.md$/, '')
+          const raw = await fs.readFile(path.join(notesDir, file), 'utf8')
+          const { data, content } = matter(raw)
+          const title = (data as any).title || slug
+          const text = `${title} ${content}`.toLowerCase()
+          if (!q || text.includes(q)) {
+            results.push({
+              type: 'garden',
+              title,
+              url: `/digital-garden/${slug}`,
+              snippet: content.slice(0, 200),
+            })
+          }
         }
+      } catch (error) {
+        console.error('Failed to search digital garden notes', error)
       }
-    } catch (error) {
-      console.error('Failed to search digital garden notes', error)
     }
   }
 


### PR DESCRIPTION
## Summary
- read digital garden notes from public/{locale}/digital-garden
- search across English and Spanish digital garden notes
- document digital garden note locations

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688e05ae60dc83269b06107f6392827c