### PR TITLE
feat: load nostr translations from public

### DIFF
--- a/app/api/nostr-profile/description/route.ts
+++ b/app/api/nostr-profile/description/route.ts
@@ -2,9 +2,17 @@ import { NextResponse } from "next/server";
 import path from "path";
 import { promises as fs } from "fs";
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const filePath = path.join(process.cwd(), "nostr-translations", "es", "description.md");
+    const { searchParams } = new URL(request.url);
+    const locale = searchParams.get("locale") || "es";
+    const filePath = path.join(
+      process.cwd(),
+      "public",
+      locale,
+      "nostr",
+      "description.md"
+    );
     const content = await fs.readFile(filePath, "utf8");
     return new NextResponse(content, {
       status: 200,

--- a/app/api/nostr-translations/[id]/route.ts
+++ b/app/api/nostr-translations/[id]/route.ts
@@ -21,7 +21,16 @@ export async function GET(
       }
     }
 
-    const filePath = path.join(process.cwd(), "nostr-translations", `${id}.md`);
+    const { searchParams } = new URL(request.url);
+    const locale = searchParams.get("locale") || "es";
+
+    const filePath = path.join(
+      process.cwd(),
+      "public",
+      locale,
+      "nostr",
+      `${id}.md`
+    );
     const raw = await fs.readFile(filePath, "utf8");
     const { data, content } = matter(raw);
     return NextResponse.json({ data, content });


### PR DESCRIPTION
## Summary
- load Nostr profile translations from public locale folders
- serve Nostr post translations based on locale
- expose locale-aware translation API endpoints

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688e05ae60dc83269b06107f6392827c