### PR TITLE
Fix Spanish locale blog note translation redirect

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -11,16 +11,8 @@ import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
 import { nip19 } from "nostr-tools"
 
-export async function generateStaticParams() {
-  const settings = getNostrSettings()
-  if (!settings.ownerNpub) return []
-  try {
-    const posts = await nostrClient.fetchPosts(settings.ownerNpub, settings.maxPosts || 50)
-    return posts.map((post) => ({ id: post.id }))
-  } catch {
-    return []
-  }
-}
+export const dynamic = "force-dynamic"
+export const revalidate = 0
 
 export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"


### PR DESCRIPTION
## Summary
- Ensure individual blog posts are rendered dynamically so Spanish locale shows translations instead of redirecting to the English version.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e090a8bf483269d7efd7cf1df2ffe