### PR TITLE
fix: ensure blog translations display correctly

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -119,6 +119,7 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
             <Link
               href="/blog"
               className="text-blue-600 hover:underline"
+              prefetch={false}
             >
               ← Back to Blog
             </Link>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -258,6 +258,7 @@ export default function BlogPage() {
                 key={post.id}
                 href={`/blog/${post.id}`}
                 className="group block"
+                prefetch={false}
               >
                 <Card
                   className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-1"


### PR DESCRIPTION
## Summary
- prevent stale English cache by disabling prefetch on blog links
- disable prefetch on back-to-blog link to always load current locale

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688e090a8bf483269d7efd7cf1df2ffe