### PR TITLE
fix: disable prefetch to respect locale

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -257,6 +257,7 @@ export default function BlogPage() {
               <Link
                 key={post.id}
                 href={`/blog/${post.id}`}
+                prefetch={false}
                 className="group block"
               >
                 <Card

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -330,6 +330,7 @@ export default function HomePage() {
                     ? `/digital-garden/${post.id}`
                     : `/blog/${post.id}`
                 }
+                prefetch={false}
                 className="group block"
               >
                 <Card


### PR DESCRIPTION
## Summary
- prevent Next.js prefetch from caching English blog posts
- ensure home page links respect current locale when opening posts

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688e090a8bf483269d7efd7cf1df2ffe