### PR TITLE
Preserve locale when opening Nostr notes

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -11,6 +11,8 @@ import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
 import { nip19 } from "nostr-tools"
 
+export const dynamic = "force-dynamic"
+
 export async function generateStaticParams() {
   const settings = getNostrSettings()
   if (!settings.ownerNpub) return []
@@ -22,12 +24,21 @@ export async function generateStaticParams() {
   }
 }
 
-export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+  searchParams,
+}: {
+  params: { id: string }
+  searchParams: { lang?: string }
+}): Promise<Metadata> {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"
   try {
     const cookieStore = cookies()
     const locale =
-      (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es") || "en"
+      (searchParams.lang === "es"
+        ? "es"
+        : (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es")) ||
+      "en"
     const post = await nostrClient.fetchPost(params.id, locale)
     if (!post) {
       return { title: "Post not found" }
@@ -51,12 +62,21 @@ export async function generateMetadata({ params }: { params: { id: string } }): 
   }
 }
 
-export default async function BlogPostPage({ params }: { params: { id: string } }) {
+export default async function BlogPostPage({
+  params,
+  searchParams,
+}: {
+  params: { id: string }
+  searchParams: { lang?: string }
+}) {
   const { id } = params
   const settings = getNostrSettings()
   const cookieStore = cookies()
   const locale =
-    (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es") || "en"
+    (searchParams.lang === "es"
+      ? "es"
+      : (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es")) ||
+    "en"
 
   if (!settings.ownerNpub || !settings.ownerNpub.startsWith("npub1")) {
     return (

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -256,7 +256,7 @@ export default function BlogPage() {
             filteredPosts.map((post) => (
               <Link
                 key={post.id}
-                href={`/blog/${post.id}`}
+                href={`/blog/${post.id}${locale === "es" ? "?lang=es" : ""}`}
                 className="group block"
               >
                 <Card

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -327,8 +327,8 @@ export default function HomePage() {
                 key={post.id}
                 href={
                   post.type === "garden"
-                    ? `/digital-garden/${post.id}`
-                    : `/blog/${post.id}`
+                    ? `/digital-garden/${post.id}${locale === "es" ? "?lang=es" : ""}`
+                    : `/blog/${post.id}${locale === "es" ? "?lang=es" : ""}`
                 }
                 className="group block"
               >

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { cookies } from 'next/headers'
 import { searchContent, SearchSource } from '@/lib/search'
 
 export default async function SearchPage({
@@ -8,7 +9,10 @@ export default async function SearchPage({
 }) {
   const query = searchParams.q ?? ''
   const source = searchParams.source as SearchSource | undefined
-  const results = await searchContent(query, source)
+  const cookieStore = cookies()
+  const locale =
+    (cookieStore.get('NEXT_LOCALE')?.value as 'en' | 'es') || 'en'
+  const results = await searchContent(query, source, locale)
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -13,7 +13,11 @@ export interface SearchResult {
   snippet: string
 }
 
-export async function searchContent(query: string, source?: SearchSource): Promise<SearchResult[]> {
+export async function searchContent(
+  query: string,
+  source?: SearchSource,
+  locale: 'en' | 'es' = 'en',
+): Promise<SearchResult[]> {
   const q = query.toLowerCase()
   const results: SearchResult[] = []
 
@@ -24,7 +28,7 @@ export async function searchContent(query: string, source?: SearchSource): Promi
 
   if (includeNostr && settings.ownerNpub) {
     try {
-      const posts = await fetchNostrPosts(settings.ownerNpub, settings.maxPosts)
+      const posts = await fetchNostrPosts(settings.ownerNpub, settings.maxPosts, locale)
       for (const post of posts) {
         const postType: SearchSource = post.type === 'article' ? 'article' : 'nostr'
         if (source && source !== postType) continue
@@ -33,7 +37,7 @@ export async function searchContent(query: string, source?: SearchSource): Promi
           results.push({
             type: postType,
             title: post.title || (post.content.length > 60 ? post.content.slice(0, 60) + '…' : post.content),
-            url: `/blog/${post.id}`,
+            url: `/blog/${post.id}${locale === 'es' ? '?lang=es' : ''}`,
             snippet: post.summary || post.content.slice(0, 200),
           })
         }


### PR DESCRIPTION
## Summary
- Add `?lang=es` to blog and home page links so Spanish readers open translations
- Read `lang` query when rendering posts and search results to serve localized content
- Pass locale through search utilities for consistent URLs

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688e090a8bf483269d7efd7cf1df2ffe