### PR TITLE
Enable i18n routing for Spanish blog pages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,6 +12,10 @@ const nextConfig = {
   experimental: {
     serverComponentsExternalPackages: ['nostr-tools']
   },
+  i18n: {
+    locales: ['en', 'es'],
+    defaultLocale: 'en',
+  },
   webpack: (config) => {
     config.resolve.fallback = {
       ...config.resolve.fallback,


### PR DESCRIPTION
## Summary
- enable Next.js i18n with English and Spanish locales to support `/es` paths and fix 404s on Spanish blog pages

## Testing
- `pnpm lint`
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_688e0dba30b4832694885a10508f3675