### PR TITLE
Handle locale-prefixed routes

### DIFF
--- a/components/locale-provider.tsx
+++ b/components/locale-provider.tsx
@@ -31,6 +31,10 @@ export function I18nProvider({ children }: { children: ReactNode }) {
       if (stored === "en" || stored === "es") {
         return stored
       }
+      const cookieMatch = document.cookie.match(/NEXT_LOCALE=(en|es)/)
+      if (cookieMatch) {
+        return cookieMatch[1] as Locale
+      }
     }
     return "en"
   })

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+const LOCALES = ['en', 'es'] as const
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+  const firstSegment = pathname.split('/')[1]
+  if (LOCALES.includes(firstSegment as any)) {
+    const locale = firstSegment as typeof LOCALES[number]
+    const newPath = pathname.replace(`/${locale}`, '') || '/'
+    const url = request.nextUrl.clone()
+    url.pathname = newPath
+    const response = NextResponse.rewrite(url)
+    response.cookies.set('NEXT_LOCALE', locale, {
+      path: '/',
+      maxAge: 60 * 60 * 24 * 365,
+    })
+    return response
+  }
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/((?!_next/|.*\..*).*)'],
+}


### PR DESCRIPTION
## Summary
- add middleware to rewrite `/en` and `/es` paths and set locale cookie
- initialize locale from `NEXT_LOCALE` cookie when no value in localStorage

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688e0dba30b4832694885a10508f3675