### PR TITLE
fix: fetch translated posts in detail view

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -11,6 +11,9 @@ import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
 import { nip19 } from "nostr-tools"
 
+export const dynamic = "force-dynamic"
+export const revalidate = 0
+
 export async function generateStaticParams() {
   const settings = getNostrSettings()
   if (!settings.ownerNpub) return []


### PR DESCRIPTION
## Summary
- disable static caching for blog post page to respect locale-specific translations

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688e0f4597848326a5d9f9a716ce912e