### PR TITLE
fix: disable prefetch for translated posts

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -258,6 +258,7 @@ export default function BlogPage() {
                 key={post.id}
                 href={`/blog/${post.id}`}
                 className="group block"
+                prefetch={false}
               >
                 <Card
                   className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-1"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -331,6 +331,7 @@ export default function HomePage() {
                     : `/blog/${post.id}`
                 }
                 className="group block"
+                prefetch={false}
               >
                 <Card
                   className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-1"


### PR DESCRIPTION
## Summary
- prevent Next.js from prefetching blog post pages so Spanish translations are always fetched

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688e0f4597848326a5d9f9a716ce912e