### PR TITLE
Add YAML front matter and metadata to project pages

### DIFF
--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from "next/headers"
 import fs from "fs/promises"
 import path from "path"
 import { marked } from "marked"
+import matter from "gray-matter"
 
 export async function generateStaticParams() {
   const dir = path.join(process.cwd(), "public", "en", "projects")
@@ -23,11 +24,51 @@ export default async function ProjectPage({ params }: { params: { slug: string }
   } catch {
     notFound()
   }
-  const html = marked.parse(markdown || "")
+
+  const { content, data } = matter(markdown || "")
+  const html = marked.parse(content || "")
+  const links = (data as any).links as {
+    demo?: string
+    source?: string
+    website?: string
+  }
+
+  const linkLabels = {
+    demo: locale === "es" ? "Demo en vivo" : "Live Demo",
+    source: locale === "es" ? "Código fuente" : "Source Code",
+    website: locale === "es" ? "Sitio web" : "Website",
+  }
 
   return (
     <div className="container mx-auto max-w-3xl px-4 py-8">
       <article className="prose dark:prose-invert">
+        {data.title && <h1>{data.title as string}</h1>}
+        {data.description && <p>{data.description as string}</p>}
+        {links && (
+          <ul>
+            {links.demo && (
+              <li>
+                <a href={links.demo} target="_blank" rel="noopener noreferrer">
+                  {linkLabels.demo}
+                </a>
+              </li>
+            )}
+            {links.source && (
+              <li>
+                <a href={links.source} target="_blank" rel="noopener noreferrer">
+                  {linkLabels.source}
+                </a>
+              </li>
+            )}
+            {links.website && (
+              <li>
+                <a href={links.website} target="_blank" rel="noopener noreferrer">
+                  {linkLabels.website}
+                </a>
+              </li>
+            )}
+          </ul>
+        )}
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </article>
     </div>

--- a/public/en/projects/passwordmanagerweb.md
+++ b/public/en/projects/passwordmanagerweb.md
@@ -1,6 +1,10 @@
-# Password Manager v2
-
-Deterministic password vault with decentralized Nostr backup.
+---
+title: Password Manager v2
+description: Deterministic password vault with decentralized Nostr backup.
+links:
+  demo: https://fabricio333.github.io/PasswordManagerWeb/
+  source: https://github.com/Fabricio333/PasswordManagerWeb
+---
 
 ## Features
 - Browser-based, offline-capable password manager using BIP39 seed phrases and SHA-256 for deterministic password generation.
@@ -8,6 +12,3 @@ Deterministic password vault with decentralized Nostr backup.
 - Local session encryption with password-based AES protection stored in localStorage.
 - Privacy-focused and portable: works entirely offline, mobile-friendly, and avoids central storage or server reliance.
 
-[Live Demo](https://fabricio333.github.io/PasswordManagerWeb/)
-
-[Source Code on GitHub](https://github.com/Fabricio333/PasswordManagerWeb)

--- a/public/en/projects/wearebitcoin.md
+++ b/public/en/projects/wearebitcoin.md
@@ -1,6 +1,9 @@
-# WeAreBitcoin.org
-
-Content Writer and Developer at WeAreBitcoin.org, a Bitcoin education platform focused on self-custody and sound money principles.
+---
+title: WeAreBitcoin.org
+description: Content Writer and Developer at WeAreBitcoin.org, a Bitcoin education platform focused on self-custody and sound money principles.
+links:
+  website: https://wearebitcoin.org
+---
 
 ## Responsibilities
 - Write, translate, and localize articles on Bitcoin, Austrian economics, and self-sovereignty.
@@ -10,3 +13,4 @@ Content Writer and Developer at WeAreBitcoin.org, a Bitcoin education platform f
 - Collaborate on visual layouts and UX to enhance engagement and learning.
 
 This is a test article for the project page.
+

--- a/public/en/projects/webworkouttimer.md
+++ b/public/en/projects/webworkouttimer.md
@@ -1,11 +1,12 @@
-# Web WorkOut Timer
-
-Web-based workout timer that lets you configure exercise and rest intervals directly in the browser.
+---
+title: Web WorkOut Timer
+description: Web-based workout timer that lets you configure exercise and rest intervals directly in the browser.
+links:
+  demo: https://fabricio333.github.io/WebWorkOutTimer/
+  source: https://github.com/fabricio333/WebWorkOutTimer
+---
 
 ## Responsibilities
 - Designed intuitive controls for setting workout and rest durations.
 - Implemented start, pause, and reset functionality with audio alerts.
 
-[Live Demo](https://fabricio333.github.io/WebWorkOutTimer/)
-
-[Source Code on GitHub](https://github.com/fabricio333/WebWorkOutTimer)

--- a/public/es/projects/passwordmanagerweb.md
+++ b/public/es/projects/passwordmanagerweb.md
@@ -1,6 +1,10 @@
-# Password Manager v2
-
-Bóveda de contraseñas determinística con respaldo descentralizado en Nostr.
+---
+title: Password Manager v2
+description: Bóveda de contraseñas determinística con respaldo descentralizado en Nostr.
+links:
+  demo: https://fabricio333.github.io/PasswordManagerWeb/
+  source: https://github.com/Fabricio333/PasswordManagerWeb
+---
 
 ## Características
 - Gestor de contraseñas basado en el navegador y capaz de funcionar sin conexión usando frases semilla BIP39 y SHA-256 para la generación determinística de contraseñas.
@@ -8,6 +12,3 @@ Bóveda de contraseñas determinística con respaldo descentralizado en Nostr.
 - Cifrado de sesión local con protección AES basada en contraseña almacenada en localStorage.
 - Enfoque en la privacidad y portabilidad: funciona totalmente sin conexión, es apto para móviles y evita almacenamiento central o dependencia de servidores.
 
-[Demo en vivo](https://fabricio333.github.io/PasswordManagerWeb/)
-
-[Código fuente en GitHub](https://github.com/Fabricio333/PasswordManagerWeb)

--- a/public/es/projects/wearebitcoin.md
+++ b/public/es/projects/wearebitcoin.md
@@ -1,6 +1,9 @@
-# WeAreBitcoin.org
-
-Redactor de contenido y desarrollador en WeAreBitcoin.org, una plataforma educativa sobre Bitcoin enfocada en la autocustodia y los principios del dinero sano.
+---
+title: WeAreBitcoin.org
+description: Redactor de contenido y desarrollador en WeAreBitcoin.org, una plataforma educativa sobre Bitcoin enfocada en la autocustodia y los principios del dinero sano.
+links:
+  website: https://wearebitcoin.org
+---
 
 ## Responsabilidades
 - Escribir, traducir y localizar artículos sobre Bitcoin, economía austríaca y autosoberanía.
@@ -10,3 +13,4 @@ Redactor de contenido y desarrollador en WeAreBitcoin.org, una plataforma educat
 - Colaborar en diseños visuales y UX para mejorar la participación y el aprendizaje.
 
 Este es un artículo de prueba para la página del proyecto.
+

--- a/public/es/projects/webworkouttimer.md
+++ b/public/es/projects/webworkouttimer.md
@@ -1,11 +1,12 @@
-# Web WorkOut Timer
-
-Temporizador de entrenamiento basado en la web que permite configurar intervalos de ejercicio y descanso directamente en el navegador.
+---
+title: Web WorkOut Timer
+description: Temporizador de entrenamiento basado en la web que permite configurar intervalos de ejercicio y descanso directamente en el navegador.
+links:
+  demo: https://fabricio333.github.io/WebWorkOutTimer/
+  source: https://github.com/fabricio333/WebWorkOutTimer
+---
 
 ## Responsabilidades
 - Diseñé controles intuitivos para establecer las duraciones de ejercicio y descanso.
 - Implementé funciones de inicio, pausa y reinicio con alertas de audio.
 
-[Demo en vivo](https://fabricio333.github.io/WebWorkOutTimer/)
-
-[Código fuente en GitHub](https://github.com/fabricio333/WebWorkOutTimer)


### PR DESCRIPTION
## Summary
- add front matter parser and localized link rendering for project details
- move project links into YAML metadata for English and Spanish markdown files

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688e14a7a64083269be43893e7b66532