### PR TITLE
Refresh page after locale change

### DIFF
--- a/components/language-toggle.tsx
+++ b/components/language-toggle.tsx
@@ -2,20 +2,12 @@
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useI18n } from "@/components/locale-provider"
-import { useRouter } from "next/navigation"
 
 export function LanguageToggle() {
   const { locale, setLocale } = useI18n()
-  const router = useRouter()
 
   return (
-    <Select
-      value={locale}
-      onValueChange={(v) => {
-        setLocale(v as "en" | "es")
-        router.refresh()
-      }}
-    >
+    <Select value={locale} onValueChange={(v) => setLocale(v as "en" | "es")}>
       <SelectTrigger className="w-[80px]">
         <SelectValue />
       </SelectTrigger>

--- a/components/locale-provider.tsx
+++ b/components/locale-provider.tsx
@@ -1,6 +1,14 @@
 "use client"
 
-import React, {createContext, useContext, useState, useEffect, ReactNode} from "react"
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+  useRef,
+} from "react"
+import { useRouter } from "next/navigation"
 import en from "@/locales/en.json"
 import es from "@/locales/es.json"
 
@@ -35,13 +43,21 @@ export function I18nProvider({ children }: { children: ReactNode }) {
     return "en"
   })
 
+  const router = useRouter()
+  const firstRender = useRef(true)
+
   useEffect(() => {
     if (typeof window !== "undefined") {
       localStorage.setItem("locale", locale)
       document.documentElement.lang = locale
       document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=31536000`
+      if (firstRender.current) {
+        firstRender.current = false
+      } else {
+        router.refresh()
+      }
     }
-  }, [locale])
+  }, [locale, router])
 
   const t = (key: string) => {
     const value = getNested(translations[locale], key)


### PR DESCRIPTION
## Summary
- refresh router after setting cookie for locale change
- simplify language toggle to rely on context

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688e9a854f2c8326bad299afb44fe31b