### PR TITLE
fix: improve blog card mobile layout

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -241,7 +241,7 @@ export default function BlogPage() {
         </Card>
 
         {/* Posts Grid */}
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
           {filteredPosts.length === 0 ? (
             <div className="col-span-full">
               <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">


### PR DESCRIPTION
## Summary
- ensure blog cards display in a single column on mobile devices

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688ec6636788832689ce4badee96bed5