### PR TITLE
feat: detect locale from ip

### DIFF
--- a/components/locale-provider.tsx
+++ b/components/locale-provider.tsx
@@ -39,6 +39,10 @@ export function I18nProvider({ children }: { children: ReactNode }) {
       if (stored === "en" || stored === "es") {
         return stored
       }
+      const htmlLang = document.documentElement.lang
+      if (htmlLang === "en" || htmlLang === "es") {
+        return htmlLang as Locale
+      }
     }
     return "en"
   })


### PR DESCRIPTION
## Summary
- detect user locale from IP-based country header and persist locale cookie
- sync client locale with server-provided language

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688ec5e06198832697a0cfc74ea65171