### PR TITLE
feat: add all search filter

### DIFF
--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -16,7 +16,7 @@ import { useI18n } from "@/components/locale-provider"
 
 export function SearchBar() {
   const [term, setTerm] = useState("")
-  const [source, setSource] = useState("nostr")
+  const [source, setSource] = useState("all")
   const router = useRouter()
   const { t } = useI18n()
 
@@ -43,6 +43,7 @@ export function SearchBar() {
         <SelectTrigger
           className={cn(
             "w-[130px]",
+            source === "all" && "text-blue-500",
             source === "nostr" && "text-purple-500",
             source === "article" && "text-orange-500",
             source === "garden" && "text-green-500"
@@ -51,6 +52,9 @@ export function SearchBar() {
           <SelectValue placeholder={t("search.filter")} />
         </SelectTrigger>
         <SelectContent>
+          <SelectItem value="all" className="text-blue-500">
+            {t("search.all")}
+          </SelectItem>
           <SelectItem value="nostr" className="text-purple-500">
             {t("search.nostr")}
           </SelectItem>

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -4,10 +4,10 @@ import matter from 'gray-matter'
 import { fetchNostrPosts } from '@/lib/nostr'
 import { getNostrSettings } from '@/lib/nostr-settings'
 
-export type SearchSource = 'nostr' | 'article' | 'garden'
+export type SearchSource = 'all' | 'nostr' | 'article' | 'garden'
 
 export interface SearchResult {
-  type: SearchSource
+  type: Exclude<SearchSource, 'all'>
   title: string
   url: string
   snippet: string
@@ -19,15 +19,17 @@ export async function searchContent(query: string, source?: SearchSource): Promi
 
   const settings = getNostrSettings()
 
-  const includeNostr = !source || source === 'nostr' || source === 'article'
-  const includeGarden = !source || source === 'garden'
+  const includeNostr =
+    !source || source === 'all' || source === 'nostr' || source === 'article'
+  const includeGarden = !source || source === 'all' || source === 'garden'
 
   if (includeNostr && settings.ownerNpub) {
     try {
       const posts = await fetchNostrPosts(settings.ownerNpub, settings.maxPosts)
       for (const post of posts) {
-        const postType: SearchSource = post.type === 'article' ? 'article' : 'nostr'
-        if (source && source !== postType) continue
+        const postType: Exclude<SearchSource, 'all'> =
+          post.type === 'article' ? 'article' : 'nostr'
+        if (source && source !== 'all' && source !== postType) continue
         const text = `${post.title ?? ''} ${post.summary ?? ''} ${post.content}`.toLowerCase()
         if (!q || text.includes(q)) {
           results.push({

--- a/locales/en.json
+++ b/locales/en.json
@@ -17,6 +17,7 @@
   "search": {
     "placeholder": "Search...",
     "filter": "Filter",
+    "all": "📚 All",
     "nostr": "⚡ Nostr",
     "articles": "📝 Articles",
     "garden": "🌱 Garden"

--- a/locales/es.json
+++ b/locales/es.json
@@ -17,6 +17,7 @@
   "search": {
     "placeholder": "Buscar...",
     "filter": "Filtrar",
+    "all": "📚 Todo",
     "nostr": "⚡ Nostr",
     "articles": "📝 Artículos",
     "garden": "🌱 Jardín"


### PR DESCRIPTION
## Summary
- add `All` filter option to navbar search
- support `all` source in search logic
- localize new filter in English and Spanish

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to store in localStorage: ReferenceError: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688f5ba1d4e48326bef5c144106ef904