### PR TITLE
move locale cookie to route handler

### DIFF
--- a/app/api/locale/route.ts
+++ b/app/api/locale/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+
+export async function POST(req: Request) {
+  const { locale } = await req.json()
+  if (locale !== 'en' && locale !== 'es') {
+    return NextResponse.json({ ok: false }, { status: 400 })
+  }
+  cookies().set('NEXT_LOCALE', locale, { path: '/', maxAge: 31536000 })
+  return NextResponse.json({ ok: true })
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,15 +45,12 @@ const SPANISH_COUNTRIES = new Set([
   "VE",
 ])
 
-function detectLocale(setCookie = false): "en" | "es" {
+function detectLocale(): "en" | "es" {
   const cookieStore = cookies()
   let locale = cookieStore.get("NEXT_LOCALE")?.value as "en" | "es" | undefined
   if (!locale) {
     const country = headers().get("x-vercel-ip-country")?.toUpperCase() || ""
     locale = SPANISH_COUNTRIES.has(country) ? "es" : "en"
-    if (setCookie) {
-      cookieStore.set("NEXT_LOCALE", locale, { path: "/", maxAge: 31536000 })
-    }
   }
   return locale
 }
@@ -109,7 +106,7 @@ export default async function RootLayout({
   children: React.ReactNode
 }) {
   const siteName = await getSiteName()
-  const locale = detectLocale(true)
+  const locale = detectLocale()
   return (
     <html lang={locale} suppressHydrationWarning>
         <body className={`${inter.className} w-full`}>

--- a/components/locale-provider.tsx
+++ b/components/locale-provider.tsx
@@ -54,7 +54,14 @@ export function I18nProvider({ children }: { children: ReactNode }) {
     if (typeof window !== "undefined") {
       localStorage.setItem("locale", locale)
       document.documentElement.lang = locale
-      document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=31536000`
+      const setCookie = async () => {
+        await fetch("/api/locale", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ locale }),
+        })
+      }
+      setCookie()
       if (firstRender.current) {
         firstRender.current = false
       } else {


### PR DESCRIPTION
## Summary
- remove server-side cookie mutation and detect locale without setting cookies in layout
- add locale API route to set `NEXT_LOCALE` cookie
- update I18n provider to use the new API route when updating locale

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688f618256c083269aa35c5fcc910fe1