### PR TITLE
fix: avoid server cookie mutation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,15 +45,12 @@ const SPANISH_COUNTRIES = new Set([
   "VE",
 ])
 
-function detectLocale(setCookie = false): "en" | "es" {
+function detectLocale(): "en" | "es" {
   const cookieStore = cookies()
   let locale = cookieStore.get("NEXT_LOCALE")?.value as "en" | "es" | undefined
   if (!locale) {
     const country = headers().get("x-vercel-ip-country")?.toUpperCase() || ""
     locale = SPANISH_COUNTRIES.has(country) ? "es" : "en"
-    if (setCookie) {
-      cookieStore.set("NEXT_LOCALE", locale, { path: "/", maxAge: 31536000 })
-    }
   }
   return locale
 }
@@ -109,7 +106,7 @@ export default async function RootLayout({
   children: React.ReactNode
 }) {
   const siteName = await getSiteName()
-  const locale = detectLocale(true)
+  const locale = detectLocale()
   return (
     <html lang={locale} suppressHydrationWarning>
         <body className={`${inter.className} w-full`}>


### PR DESCRIPTION
## Summary
- prevent cookie setting in root layout to avoid server mutation errors

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688f633f9aa88326b6bce3626c19c129