### PR TITLE
feat: cache profile picture for metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -62,11 +62,11 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = detectLocale()
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"
   const url = locale === "es" ? `${siteUrl}/es` : siteUrl
-  let profileImage = "/icon.svg"
+  let profileImage = `${siteUrl}/icon.svg`
   if (ownerNpub) {
     const cached = await cacheProfilePicture(ownerNpub)
     if (cached) {
-      profileImage = cached
+      profileImage = `${siteUrl}${cached}`
     }
   }
   return {
@@ -89,10 +89,10 @@ export async function generateMetadata(): Promise<Metadata> {
       description: settings.siteDescription,
       url,
       locale: locale === "es" ? "es_ES" : "en_US",
-      images: [profileImage],
+      images: [{ url: profileImage }],
     },
     twitter: {
-      card: "summary",
+      card: "summary_large_image",
       title: siteName,
       description: settings.siteDescription,
       images: [profileImage],

--- a/lib/profile-picture-cache.ts
+++ b/lib/profile-picture-cache.ts
@@ -2,18 +2,28 @@ import { promises as fs } from "fs"
 import path from "path"
 import { fetchNostrProfile } from "./nostr"
 
-const CACHE_PATH = path.join(process.cwd(), "public", "profile-picture.jpg")
+const CACHE_BASENAME = "profile-picture"
+const CACHE_DIR = path.join(process.cwd(), "public")
 const MAX_AGE = 24 * 60 * 60 * 1000 // 24 hours
 
-export async function cacheProfilePicture(npub: string): Promise<string | null> {
+async function getExistingCache(): Promise<string | null> {
   try {
-    const stats = await fs.stat(CACHE_PATH)
+    const files = await fs.readdir(CACHE_DIR)
+    const file = files.find((f) => f.startsWith(`${CACHE_BASENAME}.`))
+    if (!file) return null
+    const stats = await fs.stat(path.join(CACHE_DIR, file))
     if (Date.now() - stats.mtimeMs < MAX_AGE) {
-      return "/profile-picture.jpg"
+      return `/${file}`
     }
   } catch {
-    // File doesn't exist or cannot be accessed
+    // Ignore missing directory or file access issues
   }
+  return null
+}
+
+export async function cacheProfilePicture(npub: string): Promise<string | null> {
+  const cached = await getExistingCache()
+  if (cached) return cached
 
   try {
     const profile = await fetchNostrProfile(npub)
@@ -22,9 +32,30 @@ export async function cacheProfilePicture(npub: string): Promise<string | null> 
 
     const res = await fetch(url)
     if (!res.ok) return null
+
+    const contentType = res.headers.get("content-type") || ""
+    let ext = ".jpg"
+    if (contentType.includes("png")) ext = ".png"
+    else if (contentType.includes("webp")) ext = ".webp"
+    else if (contentType.includes("jpeg")) ext = ".jpg"
+
     const buffer = Buffer.from(await res.arrayBuffer())
-    await fs.writeFile(CACHE_PATH, buffer)
-    return "/profile-picture.jpg"
+
+    // Remove old cached files
+    try {
+      const files = await fs.readdir(CACHE_DIR)
+      await Promise.all(
+        files
+          .filter((f) => f.startsWith(`${CACHE_BASENAME}.`))
+          .map((f) => fs.unlink(path.join(CACHE_DIR, f))),
+      )
+    } catch {
+      // Ignore errors removing old files
+    }
+
+    const fileName = `${CACHE_BASENAME}${ext}`
+    await fs.writeFile(path.join(CACHE_DIR, fileName), buffer)
+    return `/${fileName}`
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary
- cache npub profile pictures in `public/` with proper file extension
- use the cached profile picture as the OpenGraph/Twitter share image

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f681d063c8326b3f59a5865a17ccc