### PR TITLE
feat: add locale aware routing

### DIFF
--- a/app/[locale]/blog/[id]/page.tsx
+++ b/app/[locale]/blog/[id]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../blog/[id]/page"

--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../blog/page"

--- a/app/[locale]/contact/page.tsx
+++ b/app/[locale]/contact/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../contact/page"

--- a/app/[locale]/digital-garden/[slug]/page.tsx
+++ b/app/[locale]/digital-garden/[slug]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../digital-garden/[slug]/page"

--- a/app/[locale]/digital-garden/graph/page.tsx
+++ b/app/[locale]/digital-garden/graph/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../digital-garden/graph/page"

--- a/app/[locale]/digital-garden/page.tsx
+++ b/app/[locale]/digital-garden/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../digital-garden/page"

--- a/app/[locale]/lifestyle/page.tsx
+++ b/app/[locale]/lifestyle/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../lifestyle/page"

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../page"

--- a/app/[locale]/projects/[slug]/page.tsx
+++ b/app/[locale]/projects/[slug]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../projects/[slug]/page"

--- a/app/[locale]/projects/page.tsx
+++ b/app/[locale]/projects/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../projects/page"

--- a/app/[locale]/resume/page.tsx
+++ b/app/[locale]/resume/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../resume/page"

--- a/app/[locale]/search/page.tsx
+++ b/app/[locale]/search/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../search/page"

--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { localizePath } from "@/lib/utils"
 import { nostrClient, type NostrPost } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
@@ -34,7 +35,7 @@ export async function generateMetadata({ params }: { params: { id: string } }): 
     }
     const title = post.title || `${post.content.slice(0, 60)}…`
     const description = post.summary || post.content.slice(0, 160)
-    const url = `${siteUrl}/blog/${post.id}`
+    const url = `${siteUrl}${locale === 'es' ? '/es' : ''}/blog/${post.id}`
     return {
       title,
       description,
@@ -117,7 +118,7 @@ export default async function BlogPostPage({ params }: { params: { id: string } 
         <div className="container mx-auto px-4 py-8">
           <div className="mb-4">
             <Link
-              href="/blog"
+              href={localizePath(locale, "/blog")}
               className="text-blue-600 hover:underline"
               prefetch={false}
             >

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -13,6 +13,7 @@ import { fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
 import { useI18n } from "@/components/locale-provider"
+import { localizePath } from "@/lib/utils"
 
 interface NostrProfile {
   name?: string
@@ -256,7 +257,7 @@ export default function BlogPage() {
             filteredPosts.map((post) => (
               <Link
                 key={post.id}
-                href={`/blog/${post.id}`}
+                href={localizePath(locale, `/blog/${post.id}`)}
                 className="group block"
                 prefetch={false}
               >

--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { slugify } from '@/lib/slugify'
 import en from '@/locales/en.json'
 import es from '@/locales/es.json'
+import { localizePath } from '@/lib/utils'
 
 const translations = { en, es } as const
 
@@ -24,7 +25,7 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
   }
   let content = note.content.replace(/\[\[([^\]]+)\]\]/g, (_match, p1) => {
     const slug = slugify(p1)
-    return `[${p1}](/digital-garden/${slug})`
+    return `[${p1}](${localizePath(locale, `/digital-garden/${slug}`)})`
   })
   const html = marked.parse(content)
   return (
@@ -47,7 +48,7 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </article>
       <div className="mt-8">
-        <Link href="/digital-garden" className="text-blue-600 hover:underline">
+        <Link href={localizePath(locale, '/digital-garden')} className="text-blue-600 hover:underline">
           {t('digital_garden.back')}
         </Link>
       </div>

--- a/app/digital-garden/graph/page.tsx
+++ b/app/digital-garden/graph/page.tsx
@@ -5,6 +5,7 @@ import { getAllNotes } from '@/lib/digital-garden'
 import { slugify } from '@/lib/slugify'
 import en from '@/locales/en.json'
 import es from '@/locales/es.json'
+import { localizePath } from '@/lib/utils'
 
 const translations = { en, es } as const
 
@@ -36,7 +37,7 @@ export default async function DigitalGardenGraphPage() {
       <h1 className="mb-4 text-center text-3xl font-bold">{t('digital_garden.garden_graph')}</h1>
       <WikiGraph data={{ nodes, links }} />
       <div className="mt-4 text-center">
-        <Link href="/digital-garden" className="text-blue-600 hover:underline">
+        <Link href={localizePath(locale, '/digital-garden')} className="text-blue-600 hover:underline">
           {t('digital_garden.back')}
         </Link>
       </div>

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -9,7 +9,7 @@ import {
   CardContent,
 } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { cn } from '@/lib/utils'
+import { cn, localizePath } from '@/lib/utils'
 import en from '@/locales/en.json'
 import es from '@/locales/es.json'
 
@@ -42,13 +42,13 @@ export default async function DigitalGardenPage({
         {siteName}&apos;s {t('navbar.garden')}
       </h1>
       <div className="mb-4 text-center">
-        <Link href="/digital-garden/graph" className="text-blue-600 hover:underline">
+        <Link href={localizePath(locale, '/digital-garden/graph')} className="text-blue-600 hover:underline">
           {t('digital_garden.graph_view')}
         </Link>
       </div>
       {allTags.length > 0 && (
         <div className="mb-8 flex flex-wrap justify-center gap-2">
-          <Link href="/digital-garden">
+          <Link href={localizePath(locale, '/digital-garden')}>
             <Badge
               variant="outline"
               className={cn(
@@ -62,7 +62,7 @@ export default async function DigitalGardenPage({
           {allTags.map((tag) => (
             <Link
               key={tag}
-              href={{ pathname: '/digital-garden', query: { tag } }}
+              href={{ pathname: localizePath(locale, '/digital-garden'), query: { tag } }}
             >
               <Badge
                 variant="outline"
@@ -81,7 +81,7 @@ export default async function DigitalGardenPage({
         {filteredNotes.map((note) => (
           <Link
             key={note.slug}
-            href={`/digital-garden/${note.slug}`}
+            href={localizePath(locale, `/digital-garden/${note.slug}`)}
             className="block"
           >
             <Card className="h-full transition-colors hover:bg-muted">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -55,13 +55,17 @@ function detectLocale(): "en" | "es" {
   return locale
 }
 
-export async function generateMetadata(): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: {
+  params: { locale?: string }
+}): Promise<Metadata> {
   const settings = getSettings()
   const siteName = await getSiteName()
   const ownerNpub = getOwnerNpub()
-  const locale = detectLocale()
+  const detected = params.locale === "es" ? "es" : detectLocale()
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"
-  const url = locale === "es" ? `${siteUrl}/es` : siteUrl
+  const url = detected === "es" ? `${siteUrl}/es` : siteUrl
   let profileImage = "/icon.svg"
   if (ownerNpub) {
     const cached = await cacheProfilePicture(ownerNpub)
@@ -88,7 +92,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: siteName,
       description: settings.siteDescription,
       url,
-      locale: locale === "es" ? "es_ES" : "en_US",
+      locale: detected === "es" ? "es_ES" : "en_US",
       images: [profileImage],
     },
     twitter: {
@@ -102,11 +106,13 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function RootLayout({
   children,
+  params,
 }: {
   children: React.ReactNode
+  params: { locale?: string }
 }) {
   const siteName = await getSiteName()
-  const locale = detectLocale()
+  const locale = params.locale === "es" ? "es" : detectLocale()
   return (
     <html lang={locale} suppressHydrationWarning>
         <body className={`${inter.className} w-full`}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,7 @@ import { fetchNostrProfile, fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
 import { useI18n } from "@/components/locale-provider"
+import { localizePath } from "@/lib/utils"
 
 interface NostrProfile {
   name?: string
@@ -342,11 +343,12 @@ export default function HomePage() {
             filteredPosts.map((post) => (
               <Link
                 key={post.id}
-                href={
+                href={localizePath(
+                  locale,
                   post.type === "garden"
                     ? `/digital-garden/${post.id}`
-                    : `/blog/${post.id}`
-                }
+                    : `/blog/${post.id}`,
+                )}
                 className="group block"
               >
                 <Card

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -5,8 +5,11 @@ import { Button } from "@/components/ui/button"
 import { Github, ExternalLink } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
+import { cookies } from "next/headers"
+import { localizePath } from "@/lib/utils"
 
 export default function ProjectsPage() {
+  const locale = (cookies().get("NEXT_LOCALE")?.value || "en") as "en" | "es"
   const projects = [
     {
       id: "1",
@@ -79,7 +82,7 @@ export default function ProjectsPage() {
         {projects.map((project) => (
           <Card key={project.id} className="hover:shadow-lg transition-shadow">
             <CardHeader className="p-4">
-              <Link href={project.link}>
+              <Link href={localizePath(locale, project.link)}>
                 {project.emoji ? (
                   <div
                     className={`w-full aspect-square flex items-center justify-center rounded-md mb-2 ${project.emojiClass ?? "text-6xl"}`}
@@ -98,7 +101,7 @@ export default function ProjectsPage() {
               </Link>
               <CardTitle className="text-xl mb-1">{project.title}</CardTitle>
               <CardDescription className="mb-2">
-                <Link href={project.link} className="hover:underline">
+                <Link href={localizePath(locale, project.link)} className="hover:underline">
                   {project.shortDescription}
                 </Link>
               </CardDescription>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,14 +1,19 @@
 import Link from 'next/link'
+import { cookies } from 'next/headers'
 import { searchContent, SearchSource } from '@/lib/search'
 
 export default async function SearchPage({
   searchParams,
+  params,
 }: {
   searchParams: { q?: string; source?: SearchSource }
+  params?: { locale?: string }
 }) {
   const query = searchParams.q ?? ''
   const source = searchParams.source as SearchSource | undefined
-  const results = await searchContent(query, source)
+  const cookieLocale = cookies().get('NEXT_LOCALE')?.value as 'en' | 'es' | undefined
+  const locale = (params?.locale as 'en' | 'es') || cookieLocale || 'en'
+  const results = await searchContent(query, source, locale)
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/components/language-toggle.tsx
+++ b/components/language-toggle.tsx
@@ -2,12 +2,25 @@
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useI18n } from "@/components/locale-provider"
+import { useRouter, usePathname, useSearchParams } from "next/navigation"
+import { localizePath, stripLocale } from "@/lib/utils"
 
 export function LanguageToggle() {
   const { locale, setLocale } = useI18n()
+  const router = useRouter()
+  const pathname = usePathname()
+  const params = useSearchParams()
+
+  const changeLocale = (v: "en" | "es") => {
+    const base = stripLocale(pathname)
+    const query = params.toString()
+    const path = query ? `${base}?${query}` : base
+    router.push(localizePath(v, path))
+    setLocale(v)
+  }
 
   return (
-    <Select value={locale} onValueChange={(v) => setLocale(v as "en" | "es")}>
+    <Select value={locale} onValueChange={(v) => changeLocale(v as "en" | "es")}>
       <SelectTrigger className="w-[80px]">
         <SelectValue />
       </SelectTrigger>

--- a/components/locale-provider.tsx
+++ b/components/locale-provider.tsx
@@ -6,9 +6,7 @@ import React, {
   useState,
   useEffect,
   ReactNode,
-  useRef,
 } from "react"
-import { useRouter } from "next/navigation"
 import en from "@/locales/en.json"
 import es from "@/locales/es.json"
 
@@ -47,21 +45,13 @@ export function I18nProvider({ children }: { children: ReactNode }) {
     return "en"
   })
 
-  const router = useRouter()
-  const firstRender = useRef(true)
-
   useEffect(() => {
     if (typeof window !== "undefined") {
       localStorage.setItem("locale", locale)
       document.documentElement.lang = locale
       document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=31536000`
-      if (firstRender.current) {
-        firstRender.current = false
-      } else {
-        router.refresh()
-      }
     }
-  }, [locale, router])
+  }, [locale])
 
   const t = (key: string) => {
     const value = getNested(translations[locale], key)

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -8,6 +8,7 @@ import { SearchBar } from "@/components/search-bar"
 import { ModeToggle } from "@/components/mode-toggle"
 import { LanguageToggle } from "@/components/language-toggle"
 import { useI18n } from "@/components/locale-provider"
+import { localizePath } from "@/lib/utils"
 
 interface NavbarProps {
   siteName: string
@@ -25,12 +26,12 @@ const links = [
 
 export function Navbar({ siteName }: NavbarProps) {
   const [open, setOpen] = useState(false)
-  const { t } = useI18n()
+  const { t, locale } = useI18n()
 
   return (
     <nav className="border-b bg-background">
       <div className="container flex items-center gap-4 px-4 py-4">
-        <Link href="/" className="flex items-center gap-2 font-bold text-xl">
+        <Link href={localizePath(locale, "/")} className="flex items-center gap-2 font-bold text-xl">
           <Image src="/icon.svg" alt="" width={24} height={24} />
           <span>{siteName}</span>
         </Link>
@@ -38,7 +39,7 @@ export function Navbar({ siteName }: NavbarProps) {
           {links.map((link) => (
             <Link
               key={link.href}
-              href={link.href}
+              href={localizePath(locale, link.href)}
               className="text-muted-foreground hover:text-foreground"
             >
               {t(`navbar.${link.key}`)}
@@ -72,7 +73,7 @@ export function Navbar({ siteName }: NavbarProps) {
             {links.map((link) => (
               <Link
                 key={link.href}
-                href={link.href}
+                href={localizePath(locale, link.href)}
                 onClick={() => setOpen(false)}
                 className="hover:text-primary"
               >

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -7,7 +7,8 @@ import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { ModeToggle } from "@/components/mode-toggle"
 import { Menu, Home, FileText, User, Coffee, Mail, Leaf } from "lucide-react"
-import { cn } from "@/lib/utils"
+import { cn, localizePath } from "@/lib/utils"
+import { useI18n } from "@/components/locale-provider"
 import { getSettings } from "@/lib/settings"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import { fetchNostrProfile } from "@/lib/nostr"
@@ -26,6 +27,7 @@ export function Navigation() {
   const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
   const [firstName, setFirstName] = useState(() => getSettings().siteName)
+  const { locale } = useI18n()
 
   useEffect(() => {
     const settings = getNostrSettings()
@@ -45,14 +47,14 @@ export function Navigation() {
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-14 items-center">
         <div className="mr-4 hidden md:flex">
-          <Link href="/" className="mr-6 flex items-center space-x-2">
+          <Link href={localizePath(locale, "/")} className="mr-6 flex items-center space-x-2">
             <span className="hidden font-bold sm:inline-block">{firstName}</span>
           </Link>
           <nav className="flex items-center space-x-6 text-sm font-medium">
             {navigation.map((item) => (
               <Link
                 key={item.name}
-                href={item.href}
+                href={localizePath(locale, item.href)}
                 className={cn(
                   "transition-colors hover:text-foreground/80",
                   pathname === item.href ? "text-foreground" : "text-foreground/60",
@@ -74,7 +76,7 @@ export function Navigation() {
             </Button>
           </SheetTrigger>
           <SheetContent side="left" className="pr-0">
-            <Link href="/" className="flex items-center" onClick={() => setIsOpen(false)}>
+            <Link href={localizePath(locale, "/")} className="flex items-center" onClick={() => setIsOpen(false)}>
               <span className="font-bold">{firstName}</span>
             </Link>
             <div className="my-4 h-[calc(100vh-8rem)] pb-10 pl-6">
@@ -82,7 +84,7 @@ export function Navigation() {
                 {navigation.map((item) => (
                   <Link
                     key={item.name}
-                    href={item.href}
+                    href={localizePath(locale, item.href)}
                     onClick={() => setIsOpen(false)}
                     className={cn(
                       "flex items-center space-x-2 text-sm font-medium transition-colors hover:text-foreground/80",
@@ -100,7 +102,7 @@ export function Navigation() {
         </Sheet>
         <div className="flex flex-1 items-center justify-between space-x-2 md:justify-end">
           <div className="w-full flex-1 md:w-auto md:flex-none">
-            <Link href="/" className="flex items-center space-x-2 md:hidden">
+            <Link href={localizePath(locale, "/")} className="flex items-center space-x-2 md:hidden">
               <span className="font-bold">{firstName}</span>
             </Link>
           </div>

--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -10,7 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { cn } from "@/lib/utils"
+import { cn, localizePath } from "@/lib/utils"
 import { Search } from "lucide-react"
 import { useI18n } from "@/components/locale-provider"
 
@@ -18,14 +18,14 @@ export function SearchBar() {
   const [term, setTerm] = useState("")
   const [source, setSource] = useState("all")
   const router = useRouter()
-  const { t } = useI18n()
+  const { t, locale } = useI18n()
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     const params = new URLSearchParams()
     if (term) params.set("q", term)
     if (source) params.set("source", source)
-    router.push(`/search?${params.toString()}`)
+    router.push(localizePath(locale, `/search?${params.toString()}`))
   }
 
   return (

--- a/components/wiki-graph.tsx
+++ b/components/wiki-graph.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef } from 'react'
 import { useTheme } from 'next-themes'
 import * as d3 from 'd3'
+import { useI18n } from '@/components/locale-provider'
+import { localizePath } from '@/lib/utils'
 
 interface GraphData {
   nodes: { id: string; title: string }[]
@@ -12,6 +14,7 @@ interface GraphData {
 export default function WikiGraph({ data }: { data: GraphData }) {
   const ref = useRef<SVGSVGElement>(null)
   const { resolvedTheme } = useTheme()
+  const { locale } = useI18n()
 
   useEffect(() => {
     const svg = d3.select(ref.current)
@@ -54,7 +57,7 @@ export default function WikiGraph({ data }: { data: GraphData }) {
       .attr('r', 8)
       .attr('fill', nodeColor)
       .on('click', (_event, d: any) => {
-        window.location.href = `/digital-garden/${d.id}`
+        window.location.href = localizePath(locale, `/digital-garden/${d.id}`)
       })
       .call(
         d3
@@ -104,7 +107,7 @@ export default function WikiGraph({ data }: { data: GraphData }) {
     return () => {
       simulation.stop()
     }
-  }, [data, resolvedTheme])
+  }, [data, resolvedTheme, locale])
 
   return <svg ref={ref} className="h-[600px] w-full"></svg>
 }

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import matter from 'gray-matter'
 import { fetchNostrPosts } from '@/lib/nostr'
 import { getNostrSettings } from '@/lib/nostr-settings'
+import { localizePath } from '@/lib/utils'
 
 export type SearchSource = 'all' | 'nostr' | 'article' | 'garden'
 
@@ -13,7 +14,11 @@ export interface SearchResult {
   snippet: string
 }
 
-export async function searchContent(query: string, source?: SearchSource): Promise<SearchResult[]> {
+export async function searchContent(
+  query: string,
+  source?: SearchSource,
+  locale: 'en' | 'es' = 'en',
+): Promise<SearchResult[]> {
   const q = query.toLowerCase()
   const results: SearchResult[] = []
 
@@ -25,7 +30,7 @@ export async function searchContent(query: string, source?: SearchSource): Promi
 
   if (includeNostr && settings.ownerNpub) {
     try {
-      const posts = await fetchNostrPosts(settings.ownerNpub, settings.maxPosts)
+      const posts = await fetchNostrPosts(settings.ownerNpub, settings.maxPosts, locale)
       for (const post of posts) {
         const postType: Exclude<SearchSource, 'all'> =
           post.type === 'article' ? 'article' : 'nostr'
@@ -35,7 +40,7 @@ export async function searchContent(query: string, source?: SearchSource): Promi
           results.push({
             type: postType,
             title: post.title || (post.content.length > 60 ? post.content.slice(0, 60) + '…' : post.content),
-            url: `/blog/${post.id}`,
+            url: localizePath(locale, `/blog/${post.id}`),
             snippet: post.summary || post.content.slice(0, 200),
           })
         }
@@ -67,7 +72,7 @@ export async function searchContent(query: string, source?: SearchSource): Promi
             results.push({
               type: 'garden',
               title,
-              url: `/digital-garden/${slug}`,
+              url: localizePath(locale, `/digital-garden/${slug}`),
               snippet: content.slice(0, 200),
             })
             seen.add(slug)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function localizePath(locale: string, path: string) {
+  if (!path.startsWith("/")) path = `/${path}`
+  if (locale === "en") return path
+  return path === "/" ? `/${locale}` : `/${locale}${path}`
+}
+
+export function stripLocale(path: string) {
+  const stripped = path.replace(/^\/(?:en|es)(?=\/|$)/, "")
+  if (!stripped) return "/"
+  return stripped.startsWith("/") ? stripped : `/${stripped}`
+}


### PR DESCRIPTION
## Summary
- add utils to localize URL paths
- prefix navigation and links with current locale
- expose locale-prefixed routes for site pages

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688f690e91dc8326980da6264732c058