### PR TITLE
feat: ensure profile image caching for metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -91,13 +91,18 @@ export async function generateMetadata(): Promise<Metadata> {
       siteName,
       type: "website",
       locale: locale === "es" ? "es_ES" : "en_US",
-      images: [{ url: profileImage }],
+      images: [
+        {
+          url: profileImage,
+          alt: siteName,
+        },
+      ],
     },
     twitter: {
       card: "summary_large_image",
       title: siteName,
       description: settings.siteDescription,
-      images: [profileImage],
+      images: [{ url: profileImage, alt: siteName }],
     },
   }
 }

--- a/lib/profile-picture-cache.ts
+++ b/lib/profile-picture-cache.ts
@@ -26,6 +26,9 @@ export async function cacheProfilePicture(npub: string): Promise<string | null> 
   if (cached) return cached
 
   try {
+    // Ensure the cache directory exists so writes don't fail at runtime
+    await fs.mkdir(CACHE_DIR, { recursive: true })
+
     const profile = await fetchNostrProfile(npub)
     const url = profile?.picture
     if (!url) return null


### PR DESCRIPTION
## Summary
- ensure cache directory exists before writing profile image
- include alt text on Open Graph and Twitter images

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688f6e0214748326be301831aa2d13ce