### PR TITLE
Use fabri.lat in sitemap and robots

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next"
 
 export default function robots(): MetadataRoute.Robots {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://fabri.lat"
   return {
     rules: {
       userAgent: "*",

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,7 +3,7 @@ import { getNostrSettings } from "@/lib/nostr-settings"
 import { fetchNostrPosts } from "@/lib/nostr"
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://fabri.lat"
   const routes: MetadataRoute.Sitemap = [
     { url: siteUrl, lastModified: new Date() },
     { url: `${siteUrl}/blog`, lastModified: new Date() },


### PR DESCRIPTION
## Summary
- use https://fabri.lat as the default siteUrl for the generated sitemap
- use https://fabri.lat in robots.txt metadata

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688f8b29c2e48326af6a9defe7de04ec