### PR TITLE
Cache Nostr profile picture for social metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a personal blog website built with Next.js, Tailwind CSS, and Shadcn UI.
 
 ## Features
 
-- **Nostr Integration** – Fetches NIP‑23 long‑form articles and NIP‑01 notes from the relays listed in `settings.json`. Posts are cached to `public/<locale>/nostr` so they can be served as static pages for search engines. Profile information is also pulled from Nostr and cached locally.
+- **Nostr Integration** – Fetches NIP‑23 long‑form articles and NIP‑01 notes from the relays listed in `settings.json`. Posts are cached to `public/<locale>/nostr` so they can be served as static pages for search engines. Profile information and the profile picture are pulled from Nostr and cached locally for metadata.
 - **Blog** – Lists your posts with search and type filters. Each post has its own page with Markdown rendering and optional tags.
 - **Digital Garden** – Markdown notes in `digital-garden/` are rendered with `[[wikilink]]` style linking between pages.
 - **Lifestyle Page** – Shows posts tagged `#lifestyle` from Nostr alongside configurable lists of workouts, nutrition, biohacks and routines.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,14 @@ import { I18nProvider } from "@/components/locale-provider"
 
 const inter = Inter({ subsets: ["latin"] })
 
+// Pre-cache the owner's profile picture on startup for social metadata
+const ownerNpub = getOwnerNpub()
+if (ownerNpub && typeof window === "undefined") {
+  cacheProfilePicture(ownerNpub).catch((err) => {
+    console.warn("Failed to cache profile picture", err)
+  })
+}
+
 
 export const viewport: Viewport = {
   width: "device-width",
@@ -58,7 +66,6 @@ function detectLocale(): "en" | "es" {
 export async function generateMetadata(): Promise<Metadata> {
   const settings = getSettings()
   const siteName = await getSiteName()
-  const ownerNpub = getOwnerNpub()
   const locale = detectLocale()
   const headersList = headers()
   const host = headersList.get("x-forwarded-host") ||


### PR DESCRIPTION
## Summary
- Pre-cache the site owner's Nostr profile image on startup so social metadata has a stable local copy
- Document profile picture caching in README

## Testing
- `pnpm lint`
- `npm test` (missing script)


------
https://chatgpt.com/codex/tasks/task_e_688f8e594ccc832683f62f31d588dcb8