### PR TITLE
chore: use static profile picture for metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,19 +9,10 @@ import { ThemeProvider } from "@/components/theme-provider"
 // import { Footer } from "@/components/footer"
 // import { Toaster } from "@/components/ui/toaster"
 import { Navbar } from "@/components/navbar"
-import { getSettings, getSiteName, getOwnerNpub } from "@/lib/settings"
-import { cacheProfilePicture } from "@/lib/profile-picture-cache"
+import { getSettings, getSiteName } from "@/lib/settings"
 import { I18nProvider } from "@/components/locale-provider"
 
 const inter = Inter({ subsets: ["latin"] })
-
-// Pre-cache the owner's profile picture on startup for social metadata
-const ownerNpub = getOwnerNpub()
-if (ownerNpub && typeof window === "undefined") {
-  cacheProfilePicture(ownerNpub).catch((err) => {
-    console.warn("Failed to cache profile picture", err)
-  })
-}
 
 
 export const viewport: Viewport = {
@@ -75,15 +66,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteUrl =
     process.env.NEXT_PUBLIC_SITE_URL || `${protocol}://${host}`
   const url = locale === "es" ? `${siteUrl}/es` : siteUrl
-  let profileImage = `${siteUrl}/profile-picture.png` // fallback image
-  if (ownerNpub) {
-  const cached = await cacheProfilePicture(ownerNpub)
-  if (cached) {
-    profileImage = cached.startsWith("http")
-      ? cached
-      : `${siteUrl}${cached}`
-  }
-}
+  const profileImage = "/public/profile-picture.png"
 
   return {
     metadataBase: new URL(siteUrl),


### PR DESCRIPTION
## Summary
- reference static `/public/profile-picture.png` for social metadata

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688fb24b29948326aae523101f4f4ff9