### PR TITLE
Cache profile picture for metadata previews

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,8 @@ import { ThemeProvider } from "@/components/theme-provider"
 // import { Footer } from "@/components/footer"
 // import { Toaster } from "@/components/ui/toaster"
 import { Navbar } from "@/components/navbar"
-import { getSettings, getSiteName } from "@/lib/settings"
+import { getSettings, getSiteName, getOwnerNpub } from "@/lib/settings"
+import { cacheProfilePicture } from "@/lib/profile-picture-cache"
 import { I18nProvider } from "@/components/locale-provider"
 
 const inter = Inter({ subsets: ["latin"] })
@@ -66,7 +67,14 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteUrl =
     process.env.NEXT_PUBLIC_SITE_URL || `${protocol}://${host}`
   const url = locale === "es" ? `${siteUrl}/es` : siteUrl
-  const profileImage = "/profile-picture.png"
+  let profileImage = "/profile-picture.png"
+  const npub = getOwnerNpub()
+  if (npub) {
+    const cached = await cacheProfilePicture(npub)
+    if (cached) {
+      profileImage = cached
+    }
+  }
 
   return {
     metadataBase: new URL(siteUrl),


### PR DESCRIPTION
## Summary
- cache owner's Nostr profile image and reuse it for Open Graph/Twitter metadata

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688fb5a1a00c8326a5a707125c3d6d8e