### PR TITLE
Fix missing translated Nostr posts on home page

### DIFF
--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -303,16 +303,19 @@ export async function fetchNostrPosts(
     const currentPool = getPool()
 
     // Fetch both notes (kind 1) and long-form articles (kind 30023)
+    // We fetch extra events to account for posts that might be filtered out
+    // due to missing translations or duplicates.
+    const fetchLimit = limit * 3
     const filters: Filter[] = [
       {
         kinds: [1], // Notes
         authors: [pubkeyHex],
-        limit: Math.ceil(limit / 2),
+        limit: fetchLimit,
       },
       {
         kinds: [30023], // Long-form articles
         authors: [pubkeyHex],
-        limit: Math.ceil(limit / 2),
+        limit: fetchLimit,
       },
     ]
 


### PR DESCRIPTION
## Summary
- fetch more Nostr events so translated posts aren't dropped

## Testing
- `pnpm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689029f191cc8326890c93c82844652b