### PR TITLE
fix: sync initial locale to avoid hydration mismatch

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -118,7 +118,7 @@ export default async function RootLayout({
   return (
     <html lang={locale} suppressHydrationWarning>
       <body className={`${inter.className} w-full`}>
-        <I18nProvider>
+        <I18nProvider initialLocale={locale}>
           <ThemeProvider
             attribute="class"
             defaultTheme="system"

--- a/components/locale-provider.tsx
+++ b/components/locale-provider.tsx
@@ -32,23 +32,26 @@ function getNested(obj: any, path: string) {
   return path.split(".").reduce((o, k) => (o ? o[k] : undefined), obj)
 }
 
-export function I18nProvider({ children }: { children: ReactNode }) {
-  const [locale, setLocale] = useState<Locale>(() => {
-    if (typeof window !== "undefined") {
-      const stored = localStorage.getItem("locale")
-      if (stored === "en" || stored === "es") {
-        return stored
-      }
-      const htmlLang = document.documentElement.lang
-      if (htmlLang === "en" || htmlLang === "es") {
-        return htmlLang as Locale
-      }
-    }
-    return "en"
-  })
+export function I18nProvider({
+  children,
+  initialLocale,
+}: {
+  children: ReactNode
+  initialLocale: Locale
+}) {
+  const [locale, setLocale] = useState<Locale>(initialLocale)
 
   const router = useRouter()
   const firstRender = useRef(true)
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("locale")
+      if (stored === "en" || stored === "es") {
+        setLocale(stored as Locale)
+      }
+    }
+  }, [])
 
   useEffect(() => {
     if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary
- ensure I18nProvider accepts initial locale and syncs it with storage and cookies
- pass server-detected locale from layout to I18nProvider to keep client and server in sync

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68909a0402f88326b783822f5e7d7aea