### PR TITLE
feat: support locale-prefixed routes

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -259,7 +259,7 @@ export default function BlogPage() {
                 key={post.id}
                 href={
                   locale === "es" && post.translation
-                    ? `/blog/es/${post.id}`
+                    ? `/es/blog/${post.id}`
                     : `/blog/${post.id}`
                 }
                 className="group block"

--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -24,7 +24,8 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
   }
   let content = note.content.replace(/\[\[([^\]]+)\]\]/g, (_match, p1) => {
     const slug = slugify(p1)
-    return `[${p1}](/digital-garden/${slug})`
+    const base = locale === 'es' ? '/es/digital-garden' : '/digital-garden'
+    return `[${p1}](${base}/${slug})`
   })
   const html = marked.parse(content)
   return (
@@ -47,7 +48,10 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </article>
       <div className="mt-8">
-        <Link href="/digital-garden" className="text-blue-600 hover:underline">
+        <Link
+          href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}
+          className="text-blue-600 hover:underline"
+        >
           {t('digital_garden.back')}
         </Link>
       </div>

--- a/app/digital-garden/graph/page.tsx
+++ b/app/digital-garden/graph/page.tsx
@@ -36,7 +36,10 @@ export default async function DigitalGardenGraphPage() {
       <h1 className="mb-4 text-center text-3xl font-bold">{t('digital_garden.garden_graph')}</h1>
       <WikiGraph data={{ nodes, links }} />
       <div className="mt-4 text-center">
-        <Link href="/digital-garden" className="text-blue-600 hover:underline">
+        <Link
+          href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}
+          className="text-blue-600 hover:underline"
+        >
           {t('digital_garden.back')}
         </Link>
       </div>

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -42,13 +42,16 @@ export default async function DigitalGardenPage({
         {siteName}&apos;s {t('navbar.garden')}
       </h1>
       <div className="mb-4 text-center">
-        <Link href="/digital-garden/graph" className="text-blue-600 hover:underline">
+        <Link
+          href={locale === 'es' ? '/es/digital-garden/graph' : '/digital-garden/graph'}
+          className="text-blue-600 hover:underline"
+        >
           {t('digital_garden.graph_view')}
         </Link>
       </div>
       {allTags.length > 0 && (
         <div className="mb-8 flex flex-wrap justify-center gap-2">
-          <Link href="/digital-garden">
+          <Link href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}>
             <Badge
               variant="outline"
               className={cn(
@@ -62,7 +65,10 @@ export default async function DigitalGardenPage({
           {allTags.map((tag) => (
             <Link
               key={tag}
-              href={{ pathname: '/digital-garden', query: { tag } }}
+              href={{
+                pathname: locale === 'es' ? '/es/digital-garden' : '/digital-garden',
+                query: { tag },
+              }}
             >
               <Badge
                 variant="outline"
@@ -81,7 +87,11 @@ export default async function DigitalGardenPage({
         {filteredNotes.map((note) => (
           <Link
             key={note.slug}
-            href={`/digital-garden/${note.slug}`}
+            href={
+              locale === 'es'
+                ? `/es/digital-garden/${note.slug}`
+                : `/digital-garden/${note.slug}`
+            }
             className="block"
           >
             <Card className="h-full transition-colors hover:bg-muted">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -346,9 +346,11 @@ export default function HomePage() {
                 key={post.id}
                 href={
                   post.type === "garden"
-                    ? `/digital-garden/${post.id}`
+                    ? locale === "es"
+                      ? `/es/digital-garden/${post.id}`
+                      : `/digital-garden/${post.id}`
                     : locale === "es" && post.translation
-                    ? `/blog/es/${post.id}`
+                    ? `/es/blog/${post.id}`
                     : `/blog/${post.id}`
                 }
                 className="group block"

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { cookies } from 'next/headers'
 import { searchContent, SearchSource } from '@/lib/search'
 
 export default async function SearchPage({
@@ -6,6 +7,7 @@ export default async function SearchPage({
 }: {
   searchParams: { q?: string; source?: SearchSource }
 }) {
+  const locale = (cookies().get('NEXT_LOCALE')?.value || 'en') as 'en' | 'es'
   const query = searchParams.q ?? ''
   const source = searchParams.source as SearchSource | undefined
   const results = await searchContent(query, source)
@@ -20,7 +22,10 @@ export default async function SearchPage({
           {results.map((res, idx) => (
             <li key={idx} className="rounded border p-4">
               <div className="mb-1 text-sm capitalize text-muted-foreground">{res.type}</div>
-              <Link href={res.url} className="font-semibold hover:underline">
+              <Link
+                href={locale === 'es' ? `/es${res.url}` : res.url}
+                className="font-semibold hover:underline"
+              >
                 {res.title}
               </Link>
               <p className="text-sm text-muted-foreground">{res.snippet}</p>

--- a/components/locale-provider.tsx
+++ b/components/locale-provider.tsx
@@ -58,10 +58,19 @@ export function I18nProvider({
       localStorage.setItem("locale", locale)
       document.documentElement.lang = locale
       document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=31536000`
+      const path = window.location.pathname
       if (firstRender.current) {
         firstRender.current = false
       } else {
-        router.refresh()
+        if (locale === "es" && !path.startsWith("/es")) {
+          const target = path === "/" ? "/es" : `/es${path}`
+          router.push(target)
+        } else if (locale === "en" && path.startsWith("/es")) {
+          const target = path.replace(/^\/es/, "") || "/"
+          router.push(target)
+        } else {
+          router.refresh()
+        }
       }
     }
   }, [locale, router])

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -25,12 +25,15 @@ const links = [
 
 export function Navbar({ siteName }: NavbarProps) {
   const [open, setOpen] = useState(false)
-  const { t } = useI18n()
+  const { t, locale } = useI18n()
+
+  const withLocale = (href: string) =>
+    locale === "es" ? (href === "/" ? "/es" : `/es${href}`) : href
 
   return (
     <nav className="border-b bg-background">
       <div className="container flex items-center gap-4 px-4 py-4">
-        <Link href="/" className="flex items-center gap-2 font-bold text-xl">
+        <Link href={withLocale("/")} className="flex items-center gap-2 font-bold text-xl">
           <Image src="/icon.svg" alt="" width={24} height={24} />
           <span>{siteName}</span>
         </Link>
@@ -38,7 +41,7 @@ export function Navbar({ siteName }: NavbarProps) {
           {links.map((link) => (
             <Link
               key={link.href}
-              href={link.href}
+              href={withLocale(link.href)}
               className="text-muted-foreground hover:text-foreground"
             >
               {t(`navbar.${link.key}`)}
@@ -72,7 +75,7 @@ export function Navbar({ siteName }: NavbarProps) {
             {links.map((link) => (
               <Link
                 key={link.href}
-                href={link.href}
+                href={withLocale(link.href)}
                 onClick={() => setOpen(false)}
                 className="hover:text-primary"
               >

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
+import { useI18n } from "@/components/locale-provider"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { ModeToggle } from "@/components/mode-toggle"
@@ -25,6 +26,9 @@ const navigation = [
 export function Navigation() {
   const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
+  const { locale } = useI18n()
+  const withLocale = (href: string) =>
+    locale === "es" ? (href === "/" ? "/es" : `/es${href}`) : href
   const [firstName, setFirstName] = useState(() => getSettings().siteName)
 
   useEffect(() => {
@@ -52,10 +56,12 @@ export function Navigation() {
             {navigation.map((item) => (
               <Link
                 key={item.name}
-                href={item.href}
+                href={withLocale(item.href)}
                 className={cn(
                   "transition-colors hover:text-foreground/80",
-                  pathname === item.href ? "text-foreground" : "text-foreground/60",
+                  pathname === withLocale(item.href)
+                    ? "text-foreground"
+                    : "text-foreground/60",
                 )}
               >
                 {item.name}
@@ -74,7 +80,11 @@ export function Navigation() {
             </Button>
           </SheetTrigger>
           <SheetContent side="left" className="pr-0">
-            <Link href="/" className="flex items-center" onClick={() => setIsOpen(false)}>
+            <Link
+              href={withLocale("/")}
+              className="flex items-center"
+              onClick={() => setIsOpen(false)}
+            >
               <span className="font-bold">{firstName}</span>
             </Link>
             <div className="my-4 h-[calc(100vh-8rem)] pb-10 pl-6">
@@ -82,11 +92,13 @@ export function Navigation() {
                 {navigation.map((item) => (
                   <Link
                     key={item.name}
-                    href={item.href}
+                    href={withLocale(item.href)}
                     onClick={() => setIsOpen(false)}
                     className={cn(
                       "flex items-center space-x-2 text-sm font-medium transition-colors hover:text-foreground/80",
-                      pathname === item.href ? "text-foreground" : "text-foreground/60",
+                      pathname === withLocale(item.href)
+                        ? "text-foreground"
+                        : "text-foreground/60",
                     )}
                   >
                     <item.icon className="h-4 w-4" />
@@ -100,7 +112,7 @@ export function Navigation() {
         </Sheet>
         <div className="flex flex-1 items-center justify-between space-x-2 md:justify-end">
           <div className="w-full flex-1 md:w-auto md:flex-none">
-            <Link href="/" className="flex items-center space-x-2 md:hidden">
+            <Link href={withLocale("/")} className="flex items-center space-x-2 md:hidden">
               <span className="font-bold">{firstName}</span>
             </Link>
           </div>

--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -18,14 +18,15 @@ export function SearchBar() {
   const [term, setTerm] = useState("")
   const [source, setSource] = useState("all")
   const router = useRouter()
-  const { t } = useI18n()
+  const { t, locale } = useI18n()
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     const params = new URLSearchParams()
     if (term) params.set("q", term)
     if (source) params.set("source", source)
-    router.push(`/search?${params.toString()}`)
+    const base = locale === 'es' ? '/es/search' : '/search'
+    router.push(`${base}?${params.toString()}`)
   }
 
   return (

--- a/components/wiki-graph.tsx
+++ b/components/wiki-graph.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
+import { useI18n } from '@/components/locale-provider'
 import { useTheme } from 'next-themes'
 import * as d3 from 'd3'
 
@@ -12,6 +13,7 @@ interface GraphData {
 export default function WikiGraph({ data }: { data: GraphData }) {
   const ref = useRef<SVGSVGElement>(null)
   const { resolvedTheme } = useTheme()
+  const { locale } = useI18n()
 
   useEffect(() => {
     const svg = d3.select(ref.current)
@@ -54,7 +56,8 @@ export default function WikiGraph({ data }: { data: GraphData }) {
       .attr('r', 8)
       .attr('fill', nodeColor)
       .on('click', (_event, d: any) => {
-        window.location.href = `/digital-garden/${d.id}`
+        const base = locale === 'es' ? '/es/digital-garden' : '/digital-garden'
+        window.location.href = `${base}/${d.id}`
       })
       .call(
         d3
@@ -104,7 +107,7 @@ export default function WikiGraph({ data }: { data: GraphData }) {
     return () => {
       simulation.stop()
     }
-  }, [data, resolvedTheme])
+  }, [data, resolvedTheme, locale])
 
   return <svg ref={ref} className="h-[600px] w-full"></svg>
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  // Ignore next internal paths and static files
+  if (pathname.startsWith('/_next') || pathname.startsWith('/api') || pathname.includes('.')) {
+    return NextResponse.next()
+  }
+
+  if (pathname === '/es' || pathname.startsWith('/es/')) {
+    const url = request.nextUrl.clone()
+    url.pathname = pathname.replace(/^\/es/, '') || '/'
+    const response = NextResponse.rewrite(url)
+    response.cookies.set('NEXT_LOCALE', 'es', { path: '/', maxAge: 60 * 60 * 24 * 365 })
+    return response
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/((?!_next|api|.*\\..*).*)'],
+}


### PR DESCRIPTION
## Summary
- add middleware to rewrite `/es` requests and set `NEXT_LOCALE`
- update locale provider and navigation to push locale-prefixed paths
- adjust pages and components (blog, digital garden, search) to link to localized URLs

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68909e3f1080832682d446365b8f688e