### PR TITLE
fix: prevent long text overflow in blog cards

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -309,8 +309,8 @@ export default function BlogPage() {
                   )}
                   </CardHeader>
                   <CardContent>
-                    <div className="prose prose-slate dark:prose-invert max-w-none w-full">
-                      <p className="text-slate-700 dark:text-slate-300 leading-relaxed break-words overflow-hidden line-clamp-3">
+                    <div className="prose prose-slate dark:prose-invert max-w-none w-full break-words">
+                      <p className="text-slate-700 dark:text-slate-300 leading-relaxed break-all overflow-hidden line-clamp-3">
                         {truncateContent(post.content)}
                       </p>
                     </div>


### PR DESCRIPTION
## Summary
- ensure blog card content wraps by breaking long strings like URLs

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6890a226cfa08326a2a0fdb2471678c7