### PR TITLE
fix: prevent blog card text overflow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -404,8 +404,8 @@ export default function HomePage() {
                     )}
                   </CardHeader>
                   <CardContent>
-                    <div className="prose prose-slate dark:prose-invert max-w-none w-full">
-                      <p className="text-slate-700 dark:text-slate-300 leading-relaxed break-words overflow-hidden line-clamp-3">
+                    <div className="prose prose-slate dark:prose-invert max-w-none w-full break-words">
+                      <p className="text-slate-700 dark:text-slate-300 leading-relaxed break-all overflow-hidden line-clamp-3">
                         {truncateContent(post.content)}
                       </p>
                     </div>


### PR DESCRIPTION
## Summary
- ensure blog card content wrapper allows word wrapping
- force aggressive line breaking in blog card paragraphs

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6890cfa4f1288326abcc12273046ee79