### PR TITLE
feat: add pinned posts and remove latest limit

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -18,16 +18,8 @@ export async function generateStaticParams() {
   if (!settings.ownerNpub) return []
   try {
     const [postsEn, postsEs] = await Promise.all([
-      nostrClient.fetchPosts(
-        settings.ownerNpub,
-        settings.maxPosts || 50,
-        "en",
-      ),
-      nostrClient.fetchPosts(
-        settings.ownerNpub,
-        settings.maxPosts || 50,
-        "es",
-      ),
+      nostrClient.fetchPosts(settings.ownerNpub, undefined, "en"),
+      nostrClient.fetchPosts(settings.ownerNpub, undefined, "es"),
     ])
     const ids = new Set([...postsEn, ...postsEs].map((p) => p.id))
     return Array.from(ids).map((id) => ({ slug: [id] }))

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -11,6 +11,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Search, FileText, MessageSquare, Calendar, RefreshCw } from "lucide-react"
 import { fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
+import { getPinnedPosts } from "@/lib/settings"
 import Link from "next/link"
 import { useI18n } from "@/components/locale-provider"
 
@@ -62,9 +63,15 @@ export default function BlogPage() {
         return
       }
 
-      const postsData = await fetchNostrPosts(settings.ownerNpub, 100, locale)
-      setPosts(postsData)
-      setFilteredPosts(postsData)
+      const postsData = await fetchNostrPosts(settings.ownerNpub, undefined, locale)
+      const pinned = getPinnedPosts().blog
+      const pinnedPosts = pinned
+        .map((id) => postsData.find((p) => p.id === id))
+        .filter(Boolean) as NostrPost[]
+      const remaining = postsData.filter((p) => !pinned.includes(p.id))
+      const ordered = [...pinnedPosts, ...remaining]
+      setPosts(ordered)
+      setFilteredPosts(ordered)
     } catch (err) {
       console.error("Error loading posts:", err)
       setError(t("home.failed_load"))

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { cookies } from 'next/headers'
 import { getAllNotes } from '@/lib/digital-garden'
-import { getSiteName } from '@/lib/settings'
+import { getSiteName, getPinnedPosts } from '@/lib/settings'
 import {
   Card,
   CardHeader,
@@ -29,10 +29,16 @@ export default async function DigitalGardenPage({
 }) {
   const locale = (cookies().get('NEXT_LOCALE')?.value || 'en') as 'en' | 'es'
   const t = getT(locale)
-  const [notes, siteName] = await Promise.all([
+  const [allNotes, siteName] = await Promise.all([
     getAllNotes(locale),
     getSiteName(),
   ])
+  const pinned = getPinnedPosts().digitalGarden
+  const pinnedNotes = pinned
+    .map((id) => allNotes.find((n) => n.slug === id))
+    .filter(Boolean)
+  const remaining = allNotes.filter((n) => !pinned.includes(n.slug))
+  const notes = [...pinnedNotes, ...remaining]
   const allTags = Array.from(new Set(notes.flatMap((n) => n.tags))).sort()
   const activeTag = searchParams.tag
   const filteredNotes = activeTag

--- a/app/nostr-settings/page.tsx
+++ b/app/nostr-settings/page.tsx
@@ -20,7 +20,6 @@ export default function NostrSettingsPage() {
     relays: ["wss://relay.damus.io", "wss://relay.snort.social", "wss://nostr.wine"],
     noteEventIds: [],
     articleEventIds: [],
-    maxPosts: 10,
     enableComments: true,
     enableViews: true,
   })
@@ -40,10 +39,6 @@ export default function NostrSettingsPage() {
     setSettings((prev) => ({ ...prev, [id]: value }))
   }
 
-  const handleNumberInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { id, value } = e.target
-    setSettings((prev) => ({ ...prev, [id]: Number.parseInt(value, 10) || 0 }))
-  }
 
   const handleSwitchChange = (id: keyof NostrSettings) => (checked: boolean) => {
     setSettings((prev) => ({ ...prev, [id]: checked }))
@@ -235,23 +230,6 @@ export default function NostrSettingsPage() {
                   </Badge>
                 ))}
               </div>
-            </div>
-
-            {/* Max Posts */}
-            <div className="space-y-2">
-              <Label htmlFor="maxPosts" className="text-sm font-medium">
-                Max Posts on Homepage
-              </Label>
-              <Input
-                id="maxPosts"
-                type="number"
-                value={settings.maxPosts}
-                onChange={handleNumberInputChange}
-                min={1}
-                max={50}
-                className="bg-white/50 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600"
-              />
-              <p className="text-xs text-muted-foreground">Number of latest posts to display on the homepage (1-50).</p>
             </div>
 
             {/* Enable Comments */}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -63,8 +63,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const settings = getNostrSettings()
     if (settings.ownerNpub) {
       const [postsEn, postsEs] = await Promise.all([
-        fetchNostrPosts(settings.ownerNpub, settings.maxPosts || 50, "en"),
-        fetchNostrPosts(settings.ownerNpub, settings.maxPosts || 50, "es"),
+        fetchNostrPosts(settings.ownerNpub, undefined, "en"),
+        fetchNostrPosts(settings.ownerNpub, undefined, "es"),
       ])
       const esMap = new Map(postsEs.map((p) => [p.id, p]))
       postsEn.forEach((post) => {

--- a/lib/nostr-settings.ts
+++ b/lib/nostr-settings.ts
@@ -3,7 +3,6 @@ export interface NostrSettings {
   relays: string[];
   noteEventIds: string[];
   articleEventIds: string[];
-  maxPosts: number;
   enableComments: boolean;
   enableViews: boolean;
 }

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -25,7 +25,7 @@ export async function searchContent(query: string, source?: SearchSource): Promi
 
   if (includeNostr && settings.ownerNpub) {
     try {
-      const posts = await fetchNostrPosts(settings.ownerNpub, settings.maxPosts)
+      const posts = await fetchNostrPosts(settings.ownerNpub)
       for (const post of posts) {
         const postType: Exclude<SearchSource, 'all'> =
           post.type === 'article' ? 'article' : 'nostr'

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -11,12 +11,21 @@ export interface Settings {
   };
 }
 
+export interface PinnedPosts {
+  blog: string[]
+  digitalGarden: string[]
+}
+
 import config from "@/settings.json";
 import { fetchNostrProfile } from "./nostr";
 
 export function getSettings(): Settings {
   const site = (config as any).site as Settings;
   return site;
+}
+
+export function getPinnedPosts(): PinnedPosts {
+  return (config as any).pinnedPosts || { blog: [], digitalGarden: [] }
 }
 
 export async function getSiteName(): Promise<string> {

--- a/settings.json
+++ b/settings.json
@@ -14,13 +14,17 @@
   "nostr": {
     "ownerNpub": "npub1m9vsm9d8sy0pevcjhenwm4ny6l37dm2hsg4dnusna43ql3n5305qy4zlg4",
     "relays": ["wss://relay.damus.io", "wss://relay.snort.social", "wss://nostr.wine"],
-    "noteEventIds": [],
+    "noteEventIds": [
+      "note18hvsfzt3rhtu6h32n233kqn8uz80ekd6u7x8atqlzjcxt4t3zcmspy4fjl"
+    ],
     "articleEventIds": [],
     "enableComments": true,
     "enableViews": true
   },
   "pinnedPosts": {
-    "blog": [],
-    "digitalGarden": []
+    "blog": [
+      "note18hvsfzt3rhtu6h32n233kqn8uz80ekd6u7x8atqlzjcxt4t3zcmspy4fjl"
+    ],
+    "digitalGarden": ["biohacking", "fitness"]
   }
 }

--- a/settings.json
+++ b/settings.json
@@ -16,8 +16,11 @@
     "relays": ["wss://relay.damus.io", "wss://relay.snort.social", "wss://nostr.wine"],
     "noteEventIds": [],
     "articleEventIds": [],
-    "maxPosts": 10,
     "enableComments": true,
     "enableViews": true
+  },
+  "pinnedPosts": {
+    "blog": [],
+    "digitalGarden": []
   }
 }


### PR DESCRIPTION
## Summary
- remove homepage max post limit and allow unlimited nostr posts
- add `pinnedPosts` config to surface selected blog and garden entries
- drop `maxPosts` setting and update pages to honor pinned posts

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6890ffdc7f788326806d5e4eedc5ddf8