### PR TITLE
feat: personalize resume page metadata

### DIFF
--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { MapPin, Linkedin, Github } from "lucide-react"
 import { getSiteName } from "@/lib/settings"
+import type { Metadata } from "next"
 import { cookies } from "next/headers"
 import fs from "fs/promises"
 import path from "path"
@@ -9,6 +10,24 @@ import { marked } from "marked"
 import matter from "gray-matter"
 
 export const revalidate = 60 * 60 * 24
+
+export async function generateMetadata(): Promise<Metadata> {
+  const name = await getSiteName()
+  const title = `${name} | Resume`
+  const description = `Resume of ${name}`
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+    },
+    twitter: {
+      title,
+      description,
+    },
+  }
+}
 
 export default async function ResumePage() {
   const name = await getSiteName()

--- a/settings.json
+++ b/settings.json
@@ -2,7 +2,7 @@
   "site": {
     "showResume": true,
     "showLifestyle": true,
-    "siteName": "John Doe",
+    "siteName": "Fabricio Acosta",
     "siteDescription": "A personal blog powered by Nostr",
     "contactEmail": "",
     "socialLinks": {


### PR DESCRIPTION
## Summary
- set site owner name to Fabricio Acosta
- add resume page metadata using the owner name for title and SEO

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689102522f608326985ee2d8647c68bd