### PR TITLE
feat: render images from post links

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -306,11 +306,11 @@ export default function BlogPage() {
                         </div>
                       </div>
                       {post.title ? (
-                        <CardTitle className="text-lg leading-tight bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
+                        <CardTitle className="text-lg leading-tight bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent break-all">
                           {post.title}
                         </CardTitle>
                       ) : (
-                        <CardTitle className="text-lg leading-tight bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">
+                        <CardTitle className="text-lg leading-tight bg-gradient-to-r from-slate-900 to-slate-600 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent break-all">
                           {truncateContent(post.content, 60)}
                         </CardTitle>
                       )}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,8 +5,15 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+// Checks if a URL points to a common image extension
+export function isImageUrl(url: string): boolean {
+  return /\.(png|jpe?g|gif|webp)$/i.test(url)
+}
+
 // Extracts the first image URL from a string if present
 export function extractImageUrl(content: string): string | undefined {
-  const match = content.match(/https?:\/\/[^\s]+\.(?:png|jpe?g|gif|webp)/i)
-  return match ? match[0] : undefined
+  const urlRegex = /https?:\/\/[^\s]+/g
+  const matches = content.match(urlRegex)
+  if (!matches) return undefined
+  return matches.find((url) => isImageUrl(url))
 }


### PR DESCRIPTION
## Summary
- render images directly when post content links to image files
- handle long unbroken text in blog cards

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6891057ed6ac8326b17e13392873b698