### PR TITLE
feat: filter posts by event ids for all locales

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -22,11 +22,19 @@ export async function generateStaticParams() {
         settings.ownerNpub,
         settings.maxPosts || 50,
         "en",
+        {
+          noteIds: settings.noteEventIds,
+          articleIds: settings.articleEventIds,
+        },
       ),
       nostrClient.fetchPosts(
         settings.ownerNpub,
         settings.maxPosts || 50,
         "es",
+        {
+          noteIds: settings.noteEventIds,
+          articleIds: settings.articleEventIds,
+        },
       ),
     ])
     const ids = new Set([...postsEn, ...postsEs].map((p) => p.id))

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -18,7 +18,15 @@ export async function generateMetadata(): Promise<Metadata> {
 
   try {
     if (settings.ownerNpub) {
-      const posts = await fetchNostrPosts(settings.ownerNpub, 3, locale)
+      const posts = await fetchNostrPosts(
+        settings.ownerNpub,
+        3,
+        locale,
+        {
+          noteIds: settings.noteEventIds,
+          articleIds: settings.articleEventIds,
+        },
+      )
       const titles = posts
         .map((p) => p.title || p.content.slice(0, 50))
         .filter(Boolean)

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -63,7 +63,15 @@ export default function BlogPage() {
         return
       }
 
-      const postsData = await fetchNostrPosts(settings.ownerNpub, 100, locale)
+      const postsData = await fetchNostrPosts(
+        settings.ownerNpub,
+        100,
+        locale,
+        {
+          noteIds: settings.noteEventIds,
+          articleIds: settings.articleEventIds,
+        },
+      )
       setPosts(postsData)
       setFilteredPosts(postsData)
     } catch (err) {

--- a/app/lifestyle/page.tsx
+++ b/app/lifestyle/page.tsx
@@ -58,7 +58,15 @@ export default function LifestylePage() {
           return
         }
 
-        const allPosts = await fetchNostrPosts(settings.ownerNpub, 20, locale)
+        const allPosts = await fetchNostrPosts(
+          settings.ownerNpub,
+          20,
+          locale,
+          {
+            noteIds: settings.noteEventIds,
+            articleIds: settings.articleEventIds,
+          },
+        )
         const lifestylePosts = allPosts.filter(
           (post) =>
             post.tags.some(

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -88,7 +88,15 @@ export default function HomePage() {
       // Fetch profile, nostr posts, and garden notes
       const [profileData, nostrData, gardenData] = await Promise.all([
         fetchNostrProfile(settings.ownerNpub, locale),
-        fetchNostrPosts(settings.ownerNpub, settings.maxPosts, locale),
+        fetchNostrPosts(
+          settings.ownerNpub,
+          settings.maxPosts,
+          locale,
+          {
+            noteIds: settings.noteEventIds,
+            articleIds: settings.articleEventIds,
+          },
+        ),
         fetch("/api/digital-garden").then((res) => res.json()),
       ])
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -63,8 +63,24 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const settings = getNostrSettings()
     if (settings.ownerNpub) {
       const [postsEn, postsEs] = await Promise.all([
-        fetchNostrPosts(settings.ownerNpub, settings.maxPosts || 50, "en"),
-        fetchNostrPosts(settings.ownerNpub, settings.maxPosts || 50, "es"),
+        fetchNostrPosts(
+          settings.ownerNpub,
+          settings.maxPosts || 50,
+          "en",
+          {
+            noteIds: settings.noteEventIds,
+            articleIds: settings.articleEventIds,
+          },
+        ),
+        fetchNostrPosts(
+          settings.ownerNpub,
+          settings.maxPosts || 50,
+          "es",
+          {
+            noteIds: settings.noteEventIds,
+            articleIds: settings.articleEventIds,
+          },
+        ),
       ])
       const esMap = new Map(postsEs.map((p) => [p.id, p]))
       postsEn.forEach((post) => {

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -41,6 +41,11 @@ interface NostrPost {
   translation?: any
 }
 
+export interface FetchPostsOptions {
+  noteIds?: string[]
+  articleIds?: string[]
+}
+
 // Initialize pool
 let pool: SimplePool | null = null
 
@@ -253,9 +258,23 @@ export async function fetchNostrProfile(
 export async function fetchNostrPosts(
   npub: string,
   limit = 50,
-  locale = "en"
+  locale = "en",
+  options: FetchPostsOptions = {},
 ): Promise<NostrPost[]> {
+  const { noteIds = [], articleIds = [] } = options
+  const specificIds = [...noteIds, ...articleIds].filter(Boolean)
+
+  if (specificIds.length > 0) {
+    const posts = await Promise.all(
+      specificIds.map((id) => fetchNostrPost(id, locale)),
+    )
+    const validPosts = posts.filter((p): p is NostrPost => p !== null)
+    validPosts.sort((a, b) => b.created_at - a.created_at)
+    return validPosts.slice(0, limit)
+  }
+
   try {
+
     const cacheKey = getCacheKey("posts", `${npub}:${limit}:${locale}`)
     const useCache = locale !== "es"
 
@@ -372,9 +391,9 @@ export async function fetchNostrPosts(
       return post
     })
 
-    // If Spanish locale, filter posts by available translations
+    // If Spanish locale, attempt to load translations but include all posts
     if (locale === "es") {
-      const translated: NostrPost[] = []
+      const processed: NostrPost[] = []
       await Promise.all(
         posts.map(async (post) => {
           try {
@@ -393,21 +412,21 @@ export async function fetchNostrPosts(
               const { data, content } = matter(raw)
               post.content = content
               post.translation = data
-              translated.push(post)
             } else {
               const res = await fetch(`/api/nostr-translations/${post.id}`)
-              if (!res.ok) return
-              const data = await res.json()
-              post.content = data.content
-              post.translation = data.data
-              translated.push(post)
+              if (res.ok) {
+                const data = await res.json()
+                post.content = data.content
+                post.translation = data.data
+              }
             }
           } catch {
             // ignore missing translations
           }
+          processed.push(post)
         })
       )
-      posts = translated
+      posts = processed
     }
 
     // Remove any duplicate posts that might come from multiple relays
@@ -582,9 +601,10 @@ export class NostrClient {
   async fetchPosts(
     npub: string,
     limit?: number,
-    locale?: string
+    locale?: string,
+    options?: FetchPostsOptions,
   ): Promise<NostrPost[]> {
-    return fetchNostrPosts(npub, limit, locale)
+    return fetchNostrPosts(npub, limit, locale, options)
   }
 
   async fetchPost(id: string, locale?: string): Promise<NostrPost | null> {

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -25,7 +25,15 @@ export async function searchContent(query: string, source?: SearchSource): Promi
 
   if (includeNostr && settings.ownerNpub) {
     try {
-      const posts = await fetchNostrPosts(settings.ownerNpub, settings.maxPosts)
+      const posts = await fetchNostrPosts(
+        settings.ownerNpub,
+        settings.maxPosts,
+        "en",
+        {
+          noteIds: settings.noteEventIds,
+          articleIds: settings.articleEventIds,
+        },
+      )
       for (const post of posts) {
         const postType: Exclude<SearchSource, 'all'> =
           post.type === 'article' ? 'article' : 'nostr'


### PR DESCRIPTION
## Summary
- support fetching posts by explicit event IDs via new fetch options
- load all Spanish posts, falling back to original content when translations are missing
- wire event ID filtering into pages and search

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689104af49e88326af5ce4ef5946ebf7