### PR TITLE
fix: prevent blog card overflow

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -276,7 +276,7 @@ export default function BlogPage() {
                   className="group block"
                   prefetch={false}
                 >
-                  <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-1">
+                  <Card className="border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-1 overflow-hidden break-words">
                     {imageUrl && (
                       <Image
                         src={imageUrl}


### PR DESCRIPTION
## Summary
- prevent long notes from overflowing blog cards

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68910c927ee083268ec385a52b150f67