### PR TITLE
Filter posts and notes by locale

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -124,7 +124,15 @@ export default function HomePage() {
         }
       })
 
-      const combined = [...nostrPosts, ...gardenPosts].sort((a, b) => {
+      let combined = [...nostrPosts, ...gardenPosts]
+
+      if (locale === "es") {
+        combined = combined.filter(
+          (post) => post.type === "garden" || post.translation,
+        )
+      }
+
+      combined.sort((a, b) => {
         const aDate = a.published_at ?? a.created_at
         const bDate = b.published_at ?? b.created_at
         return bDate - aDate

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -268,7 +268,10 @@ export async function fetchNostrPosts(
     const posts = await Promise.all(
       specificIds.map((id) => fetchNostrPost(id, locale)),
     )
-    const validPosts = posts.filter((p): p is NostrPost => p !== null)
+    let validPosts = posts.filter((p): p is NostrPost => p !== null)
+    if (locale === "es") {
+      validPosts = validPosts.filter((p) => p.translation)
+    }
     validPosts.sort((a, b) => b.created_at - a.created_at)
     return validPosts.slice(0, limit)
   }
@@ -426,7 +429,7 @@ export async function fetchNostrPosts(
           processed.push(post)
         })
       )
-      posts = processed
+      posts = processed.filter((p) => p.translation)
     }
 
     // Remove any duplicate posts that might come from multiple relays


### PR DESCRIPTION
## Summary
- filter Nostr posts without Spanish translations during fetch
- avoid mixing unlocalized posts with garden notes on the home page

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68910c51f9e08326af853298d4525305