### PR TITLE
feat: add resume metadata image

### DIFF
--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -45,16 +45,27 @@ export async function generateMetadata(): Promise<Metadata> {
   }
 
   const title = siteName
+  const image = "/linkedin-picture.jpeg"
   return {
     title,
     description,
     openGraph: {
       title,
       description,
+      images: [
+        {
+          url: image,
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
     },
     twitter: {
+      card: "summary_large_image",
       title,
       description,
+      images: [image],
     },
   }
 }


### PR DESCRIPTION
## Summary
- feature: add LinkedIn picture as metadata image for resume page

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689230b15a0c8326aec2b4b371414944