### PR TITLE
feat: personalize projects page title

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -8,9 +8,13 @@ import { Github, ExternalLink } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
 import { useI18n } from "@/components/locale-provider"
+import { getSettings } from "@/lib/settings"
 
 export default function ProjectsPage() {
   const { t } = useI18n()
+  const { siteName } = getSettings()
+  const title = t("projects.title").replace("{{ownerName}}", siteName)
+
   const projects = [
     {
       id: "1",
@@ -71,9 +75,7 @@ export default function ProjectsPage() {
 
   return (
     <div className="container mx-auto px-4 py-4">
-      <h1 className="text-3xl font-bold mb-4 text-center">
-        {t("projects.title")}
-      </h1>
+      <h1 className="text-3xl font-bold mb-4 text-center">{title}</h1>
       <p className="text-lg text-muted-foreground text-center mb-6">
         {t("projects.subtitle")}
       </p>

--- a/locales/en.json
+++ b/locales/en.json
@@ -71,7 +71,7 @@
     "note": "Note"
   },
   "projects": {
-    "title": "Projects",
+    "title": "{{ownerName}}'s projects",
     "subtitle": "A collection of my work, showcasing various technologies and problem-solving approaches.",
     "github": "GitHub",
     "live_demo": "Live Demo",

--- a/locales/es.json
+++ b/locales/es.json
@@ -71,7 +71,7 @@
     "note": "Nota"
   },
   "projects": {
-    "title": "Proyectos",
+    "title": "Proyectos de {{ownerName}}",
     "subtitle": "Una colección de mi trabajo, que muestra diversas tecnologías y enfoques para resolver problemas.",
     "github": "GitHub",
     "live_demo": "Demo en vivo",


### PR DESCRIPTION
## Summary
- personalize /projects heading with site owner's name
- localize title templates for English and Spanish

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68937d104a508326bd6931acb13e4ce4