### PR TITLE
Limit initial posts with "show more" button

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -46,6 +46,7 @@ interface NostrPost {
 export default function BlogPage() {
   const [posts, setPosts] = useState<NostrPost[]>([])
   const [filteredPosts, setFilteredPosts] = useState<NostrPost[]>([])
+  const [visibleCount, setVisibleCount] = useState(20)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState("")
@@ -106,6 +107,7 @@ export default function BlogPage() {
     }
 
     setFilteredPosts(filtered)
+    setVisibleCount(20)
   }, [posts, searchTerm, selectedType])
 
   const formatDate = (timestamp: number) => {
@@ -123,6 +125,8 @@ export default function BlogPage() {
     if (content.length <= maxLength) return content
     return content.slice(0, maxLength) + "…"
   }
+
+  const visiblePosts = filteredPosts.slice(0, visibleCount)
 
   if (loading) {
     return (
@@ -263,7 +267,7 @@ export default function BlogPage() {
               </Card>
             </div>
           ) : (
-            filteredPosts.map((post) => {
+            visiblePosts.map((post) => {
               const imageUrl = post.image || extractImageUrl(post.content)
               return (
                 <Link
@@ -341,6 +345,13 @@ export default function BlogPage() {
             })
           )}
         </div>
+        {visibleCount < filteredPosts.length && (
+          <div className="mt-6 flex justify-center">
+            <Button onClick={() => setVisibleCount((c) => c + 20)} variant="outline">
+              {t("show_more")}
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -3,12 +3,7 @@ import type { Metadata } from 'next'
 import { cookies, headers } from 'next/headers'
 import { getAllNotes } from '@/lib/digital-garden'
 import { getSiteName } from '@/lib/settings'
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-} from '@/components/ui/card'
+import DigitalGardenList from '@/components/digital-garden-list'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 import en from '@/locales/en.json'
@@ -119,40 +114,7 @@ export default async function DigitalGardenPage({
           ))}
         </div>
       )}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {filteredNotes.map((note) => (
-          <Link
-            key={note.slug}
-            href={
-              locale === 'es'
-                ? `/es/digital-garden/${note.slug}`
-                : `/digital-garden/${note.slug}`
-            }
-            className="block"
-          >
-            <Card className="h-full transition-colors hover:bg-muted">
-              <CardHeader>
-                <CardTitle>{note.title}</CardTitle>
-              </CardHeader>
-              {note.tags.length > 0 && (
-                <CardContent className="pt-0">
-                  <div className="flex flex-wrap gap-2">
-                    {note.tags.map((tag) => (
-                      <Badge
-                        key={tag}
-                        variant="secondary"
-                        className="bg-green-100 text-green-700"
-                      >
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                </CardContent>
-              )}
-            </Card>
-          </Link>
-        ))}
-      </div>
+      <DigitalGardenList notes={filteredNotes} locale={locale} />
     </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -66,6 +66,7 @@ export default function HomePage() {
   const [profile, setProfile] = useState<NostrProfile | null>(null)
   const [posts, setPosts] = useState<Post[]>([])
   const [filteredPosts, setFilteredPosts] = useState<Post[]>([])
+  const [visibleCount, setVisibleCount] = useState(20)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState("")
@@ -173,6 +174,7 @@ export default function HomePage() {
     }
 
     setFilteredPosts(filtered)
+    setVisibleCount(20)
   }, [posts, searchTerm, selectedType])
 
   const formatDate = (timestamp: number) => {
@@ -187,6 +189,8 @@ export default function HomePage() {
     if (content.length <= maxLength) return content
     return content.slice(0, maxLength) + "…"
   }
+
+  const visiblePosts = filteredPosts.slice(0, visibleCount)
 
   if (loading) {
     return (
@@ -360,7 +364,7 @@ export default function HomePage() {
               </CardContent>
             </Card>
           ) : (
-            filteredPosts.map((post) => {
+            visiblePosts.map((post) => {
               const imageUrl = post.image || extractImageUrl(post.content)
               return (
                 <Link
@@ -444,6 +448,13 @@ export default function HomePage() {
             })
           )}
         </div>
+        {visibleCount < filteredPosts.length && (
+          <div className="mt-6 flex justify-center">
+            <Button onClick={() => setVisibleCount((c) => c + 20)} variant="outline">
+              {t("show_more")}
+            </Button>
+          </div>
+        )}
 
       </div>
     </div>

--- a/components/digital-garden-list.tsx
+++ b/components/digital-garden-list.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import Link from "next/link"
+import { useState } from "react"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { useI18n } from "@/components/locale-provider"
+
+interface Note {
+  slug: string
+  title: string
+  tags: string[]
+}
+
+export default function DigitalGardenList({
+  notes,
+  locale,
+}: {
+  notes: Note[]
+  locale: string
+}) {
+  const [visibleCount, setVisibleCount] = useState(12)
+  const { t } = useI18n()
+  const visibleNotes = notes.slice(0, visibleCount)
+
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {visibleNotes.map((note) => (
+          <Link
+            key={note.slug}
+            href={
+              locale === "es"
+                ? `/es/digital-garden/${note.slug}`
+                : `/digital-garden/${note.slug}`
+            }
+            className="block"
+          >
+            <Card className="h-full transition-colors hover:bg-muted">
+              <CardHeader>
+                <CardTitle>{note.title}</CardTitle>
+              </CardHeader>
+              {note.tags.length > 0 && (
+                <CardContent className="pt-0">
+                  <div className="flex flex-wrap gap-2">
+                    {note.tags.map((tag) => (
+                      <Badge
+                        key={tag}
+                        variant="secondary"
+                        className="bg-green-100 text-green-700"
+                      >
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </CardContent>
+              )}
+            </Card>
+          </Link>
+        ))}
+      </div>
+      {visibleCount < notes.length && (
+        <div className="mt-6 flex justify-center">
+          <Button
+            onClick={() => setVisibleCount((c) => c + 12)}
+            variant="outline"
+            className="border-green-500 text-green-500"
+          >
+            {t("show_more")}
+          </Button>
+        </div>
+      )}
+    </>
+  )
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -93,5 +93,6 @@
     "all": "All",
     "garden_graph": "Garden Graph",
     "back": "\u2190 Back to Garden"
-  }
+  },
+  "show_more": "Show more"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -93,5 +93,6 @@
     "all": "Todo",
     "garden_graph": "Grafo del Jardín",
     "back": "\u2190 Volver al Jardín"
-  }
+  },
+  "show_more": "Mostrar más"
 }


### PR DESCRIPTION
## Summary
- Display only 20 posts on the home and blog pages with a new "show more" button to reveal additional entries.
- Show just 12 notes on the digital garden page and load more on demand via a new client component.
- Add translations for the new button in English and Spanish.

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6893827c01308326942f1ecbeafad5c3