### PR TITLE
chore: set site url for production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_SITE_URL=https://fabri.lat

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,9 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  env: {
+    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
+  },
   experimental: {
     serverComponentsExternalPackages: ['nostr-tools']
   },


### PR DESCRIPTION
## Summary
- set NEXT_PUBLIC_SITE_URL in `.env.production`
- load site url from env in next config

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6893905c013c83268e6608f240b90e7f