### PR TITLE
refactor: centralize site url lookup

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -11,6 +11,7 @@ import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
 import { nip19 } from "nostr-tools"
 import { isImageUrl } from "@/lib/utils"
+import { getCanonicalUrl } from "@/utils/getCanonicalUrl"
 
 export const revalidate = 60 * 60 * 24
 
@@ -52,7 +53,7 @@ export async function generateMetadata({
   params: { slug: string[] }
   searchParams: { [key: string]: string | string[] | undefined }
 }): Promise<Metadata> {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"
+  const siteUrl = getCanonicalUrl()
   try {
     const slug = params.slug
     const id = slug[0]

--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import type { Metadata } from 'next'
-import { cookies, headers } from 'next/headers'
+import { cookies } from 'next/headers'
 import { marked } from 'marked'
 import { getNote } from '@/lib/digital-garden'
 import { getSiteName } from '@/lib/settings'
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge'
 import { slugify } from '@/lib/slugify'
 import en from '@/locales/en.json'
 import es from '@/locales/es.json'
+import { getCanonicalUrl } from '@/utils/getCanonicalUrl'
 
 const translations = { en, es } as const
 
@@ -27,13 +28,7 @@ export async function generateMetadata({
   if (!note) {
     return { title: gardenTitle }
   }
-  const headersList = headers()
-  const host =
-    headersList.get('x-forwarded-host') ||
-    headersList.get('host') ||
-    'localhost:3000'
-  const protocol = headersList.get('x-forwarded-proto') || 'https'
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || `${protocol}://${host}`
+  const siteUrl = getCanonicalUrl()
   const url =
     locale === 'es'
       ? `${siteUrl}/es/digital-garden/${params.slug}`

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
-import { cookies, headers } from 'next/headers'
+import { cookies } from 'next/headers'
 import { getAllNotes } from '@/lib/digital-garden'
 import { getSiteName } from '@/lib/settings'
 import DigitalGardenList from '@/components/digital-garden-list'
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 import en from '@/locales/en.json'
 import es from '@/locales/es.json'
+import { getCanonicalUrl } from '@/utils/getCanonicalUrl'
 
 const translations = { en, es } as const
 
@@ -23,11 +24,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const cookieStore = cookies()
   const locale = (cookieStore.get('NEXT_LOCALE')?.value || 'en') as 'en' | 'es'
   const t = getT(locale)
-  const headersList = headers()
-  const host =
-    headersList.get('x-forwarded-host') || headersList.get('host') || 'localhost:3000'
-  const protocol = headersList.get('x-forwarded-proto') || 'https'
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || `${protocol}://${host}`
+  const siteUrl = getCanonicalUrl()
   const url = locale === 'es' ? `${siteUrl}/es/digital-garden` : `${siteUrl}/digital-garden`
   const title = `${siteName}'s ${t('navbar.garden')}`
   return {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ import { Navbar } from "@/components/navbar"
 import { getSettings, getSiteName, getOwnerNpub } from "@/lib/settings"
 import { fetchNostrProfile } from "@/lib/nostr"
 import { I18nProvider } from "@/components/locale-provider"
+import { getCanonicalUrl } from "@/utils/getCanonicalUrl"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -59,13 +60,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const settings = getSettings()
   const siteName = await getSiteName()
   const locale = detectLocale()
-  const headersList = headers()
-  const host = headersList.get("x-forwarded-host") ||
-    headersList.get("host") ||
-    "localhost:3000"
-  const protocol = headersList.get("x-forwarded-proto") || "https"
-  const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || `${protocol}://${host}`
+  const siteUrl = getCanonicalUrl()
   const url = locale === "es" ? `${siteUrl}/es` : siteUrl
   const profileImage = "/profile-picture.png"
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,8 @@
 import type { MetadataRoute } from "next"
+import { getCanonicalUrl } from "@/utils/getCanonicalUrl"
 
 export default function robots(): MetadataRoute.Robots {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://fabri.lat"
+  const siteUrl = getCanonicalUrl()
   return {
     rules: {
       userAgent: "*",

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,9 +4,10 @@ import { fetchNostrPosts } from "@/lib/nostr"
 import { getAllNotes } from "@/lib/digital-garden"
 import fs from "fs/promises"
 import path from "path"
+import { getCanonicalUrl } from "@/utils/getCanonicalUrl"
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://fabri.lat"
+  const siteUrl = getCanonicalUrl()
   const routes: MetadataRoute.Sitemap = [
     {
       url: siteUrl,

--- a/utils/getCanonicalUrl.ts
+++ b/utils/getCanonicalUrl.ts
@@ -1,0 +1,11 @@
+import { headers } from "next/headers"
+
+export function getCanonicalUrl(): string {
+  const headersList = headers()
+  const host =
+    headersList.get("x-forwarded-host") ||
+    headersList.get("host") ||
+    "localhost:3000"
+  const protocol = headersList.get("x-forwarded-proto") || "https"
+  return process.env.NEXT_PUBLIC_SITE_URL || `${protocol}://${host}`
+}


### PR DESCRIPTION
## Summary
- add `getCanonicalUrl` utility to resolve base site URL
- refactor pages and metadata routes to use helper instead of direct `NEXT_PUBLIC_SITE_URL`

## Testing
- `pnpm lint`
- `rg "NEXT_PUBLIC_SITE_URL"`


------
https://chatgpt.com/codex/tasks/task_e_6893926a8bdc8326bed0a78d0df33d82