### PR TITLE
feat: ensure canonical blog URLs

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -11,6 +11,7 @@ import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
 import { nip19 } from "nostr-tools"
 import { isImageUrl } from "@/lib/utils"
+import { getCanonicalUrl } from "@/utils/getCanonicalUrl"
 
 export const revalidate = 60 * 60 * 24
 
@@ -52,7 +53,6 @@ export async function generateMetadata({
   params: { slug: string[] }
   searchParams: { [key: string]: string | string[] | undefined }
 }): Promise<Metadata> {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"
   try {
     const slug = params.slug
     const id = slug[0]
@@ -69,18 +69,15 @@ export async function generateMetadata({
     }
     const title = post.title || `${post.content.slice(0, 60)}…`
     const description = post.summary || post.content.slice(0, 160)
-    const url =
-      locale === "es" && post.translation
-        ? `${siteUrl}/es/blog/${post.id}`
-        : `${siteUrl}/blog/${post.id}`
+    const canonicalUrl = getCanonicalUrl(`/blog/${post.id}`)
     return {
       title,
       description,
-      alternates: { canonical: url },
+      alternates: { canonical: canonicalUrl },
       openGraph: {
         title,
         description,
-        url,
+        url: canonicalUrl,
         type: "article",
       },
     }

--- a/utils/getCanonicalUrl.ts
+++ b/utils/getCanonicalUrl.ts
@@ -1,0 +1,13 @@
+import { headers } from "next/headers"
+
+export function getCanonicalUrl(path: string): string {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL
+  if (siteUrl) {
+    return new URL(path, siteUrl).toString()
+  }
+
+  const headerList = headers()
+  const host = headerList.get("host") || "localhost:3000"
+  const protocol = headerList.get("x-forwarded-proto") || "http"
+  return `${protocol}://${host}${path}`
+}


### PR DESCRIPTION
## Summary
- add `getCanonicalUrl` utility to derive full URL from env or request headers
- use `getCanonicalUrl` in blog post metadata so canonical and og URLs always reference the real domain

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68939269525083268694ffa8348774bb