### PR TITLE
feat: add canonical URL helper and metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_SITE_URL=https://fabri.lat

--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -11,6 +11,7 @@ import { getNostrSettings } from "@/lib/nostr-settings"
 import { marked } from "marked" // For Markdown rendering
 import { nip19 } from "nostr-tools"
 import { isImageUrl } from "@/lib/utils"
+import { getCanonicalUrl } from "@/utils/getCanonicalUrl"
 
 export const revalidate = 60 * 60 * 24
 
@@ -52,7 +53,6 @@ export async function generateMetadata({
   params: { slug: string[] }
   searchParams: { [key: string]: string | string[] | undefined }
 }): Promise<Metadata> {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com"
   try {
     const slug = params.slug
     const id = slug[0]
@@ -69,10 +69,11 @@ export async function generateMetadata({
     }
     const title = post.title || `${post.content.slice(0, 60)}…`
     const description = post.summary || post.content.slice(0, 160)
-    const url =
+    const path =
       locale === "es" && post.translation
-        ? `${siteUrl}/es/blog/${post.id}`
-        : `${siteUrl}/blog/${post.id}`
+        ? `/es/blog/${post.id}`
+        : `/blog/${post.id}`
+    const url = getCanonicalUrl(path)
     return {
       title,
       description,

--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -1,12 +1,13 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import type { Metadata } from 'next'
-import { cookies, headers } from 'next/headers'
+import { cookies } from 'next/headers'
 import { marked } from 'marked'
 import { getNote } from '@/lib/digital-garden'
 import { getSiteName } from '@/lib/settings'
 import { Badge } from '@/components/ui/badge'
 import { slugify } from '@/lib/slugify'
+import { getCanonicalUrl } from '@/utils/getCanonicalUrl'
 import en from '@/locales/en.json'
 import es from '@/locales/es.json'
 
@@ -27,17 +28,11 @@ export async function generateMetadata({
   if (!note) {
     return { title: gardenTitle }
   }
-  const headersList = headers()
-  const host =
-    headersList.get('x-forwarded-host') ||
-    headersList.get('host') ||
-    'localhost:3000'
-  const protocol = headersList.get('x-forwarded-proto') || 'https'
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || `${protocol}://${host}`
-  const url =
+  const path =
     locale === 'es'
-      ? `${siteUrl}/es/digital-garden/${params.slug}`
-      : `${siteUrl}/digital-garden/${params.slug}`
+      ? `/es/digital-garden/${params.slug}`
+      : `/digital-garden/${params.slug}`
+  const url = getCanonicalUrl(path)
   const title = `${note.title} – ${gardenTitle}`
   const description = note.content
     .replace(/\[\[([^\]]+)\]\]/g, '$1')
@@ -48,8 +43,8 @@ export async function generateMetadata({
     alternates: {
       canonical: url,
       languages: {
-        en: `${siteUrl}/digital-garden/${params.slug}`,
-        es: `${siteUrl}/es/digital-garden/${params.slug}`,
+        en: getCanonicalUrl(`/digital-garden/${params.slug}`),
+        es: getCanonicalUrl(`/es/digital-garden/${params.slug}`),
       },
     },
     openGraph: {

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -1,11 +1,12 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
-import { cookies, headers } from 'next/headers'
+import { cookies } from 'next/headers'
 import { getAllNotes } from '@/lib/digital-garden'
 import { getSiteName } from '@/lib/settings'
 import DigitalGardenList from '@/components/digital-garden-list'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
+import { getCanonicalUrl } from '@/utils/getCanonicalUrl'
 import en from '@/locales/en.json'
 import es from '@/locales/es.json'
 
@@ -23,20 +24,16 @@ export async function generateMetadata(): Promise<Metadata> {
   const cookieStore = cookies()
   const locale = (cookieStore.get('NEXT_LOCALE')?.value || 'en') as 'en' | 'es'
   const t = getT(locale)
-  const headersList = headers()
-  const host =
-    headersList.get('x-forwarded-host') || headersList.get('host') || 'localhost:3000'
-  const protocol = headersList.get('x-forwarded-proto') || 'https'
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || `${protocol}://${host}`
-  const url = locale === 'es' ? `${siteUrl}/es/digital-garden` : `${siteUrl}/digital-garden`
+  const canonicalPath = locale === 'es' ? '/es/digital-garden' : '/digital-garden'
+  const url = getCanonicalUrl(canonicalPath)
   const title = `${siteName}'s ${t('navbar.garden')}`
   return {
     title,
     alternates: {
       canonical: url,
       languages: {
-        en: `${siteUrl}/digital-garden`,
-        es: `${siteUrl}/es/digital-garden`,
+        en: getCanonicalUrl('/digital-garden'),
+        es: getCanonicalUrl('/es/digital-garden'),
       },
     },
     openGraph: {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ import { Navbar } from "@/components/navbar"
 import { getSettings, getSiteName, getOwnerNpub } from "@/lib/settings"
 import { fetchNostrProfile } from "@/lib/nostr"
 import { I18nProvider } from "@/components/locale-provider"
+import { getCanonicalUrl } from "@/utils/getCanonicalUrl"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -59,14 +60,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const settings = getSettings()
   const siteName = await getSiteName()
   const locale = detectLocale()
-  const headersList = headers()
-  const host = headersList.get("x-forwarded-host") ||
-    headersList.get("host") ||
-    "localhost:3000"
-  const protocol = headersList.get("x-forwarded-proto") || "https"
-  const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || `${protocol}://${host}`
-  const url = locale === "es" ? `${siteUrl}/es` : siteUrl
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://fabri.lat"
+  const canonical = getCanonicalUrl(locale === "es" ? "/es" : "")
   const profileImage = "/profile-picture.png"
 
   let description = settings.siteDescription
@@ -83,12 +78,12 @@ export async function generateMetadata(): Promise<Metadata> {
   }
 
   return {
-    metadataBase: new URL(siteUrl),
+    metadataBase: new URL(baseUrl),
     alternates: {
-      canonical: url,
+      canonical: canonical,
       languages: {
-        en: siteUrl,
-        es: `${siteUrl}/es`,
+        en: getCanonicalUrl(),
+        es: getCanonicalUrl("/es"),
       },
     },
     title: siteName,
@@ -100,7 +95,7 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title: siteName,
       description,
-      url,
+      url: canonical,
       siteName,
       type: "website",
       locale: locale === "es" ? "es_ES" : "en_US",

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -8,6 +8,7 @@ import type { Metadata } from "next"
 import { getSettings } from "@/lib/settings"
 import en from "@/locales/en.json"
 import es from "@/locales/es.json"
+import { getCanonicalUrl } from "@/utils/getCanonicalUrl"
 
 export const revalidate = 60 * 60 * 24
 
@@ -36,9 +37,13 @@ export async function generateMetadata({
     const shortDescription =
       translations[locale]?.projects?.list?.[params.slug]?.short_description as string | undefined
 
+    const canonicalPath = locale === "es" ? `/es/projects/${params.slug}` : `/projects/${params.slug}`
     return {
       title: `${data.title as string} - ${siteName}`,
       description: shortDescription || (data.description as string | undefined),
+      alternates: {
+        canonical: getCanonicalUrl(canonicalPath),
+      },
     }
   } catch {
     return {}

--- a/utils/getCanonicalUrl.ts
+++ b/utils/getCanonicalUrl.ts
@@ -1,0 +1,5 @@
+export function getCanonicalUrl(path: string = ''): string {
+  const base = process.env.NEXT_PUBLIC_SITE_URL || 'https://fabri.lat'
+  const cleanPath = path.startsWith('/') ? path : `/${path}`
+  return `${base}${cleanPath}`
+}


### PR DESCRIPTION
## Summary
- add `getCanonicalUrl` helper and env sample
- wire canonical URLs into layout, blog posts, digital garden and project pages

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68938eb7b2148326bbbe26f788f0ef55