### PR TITLE
Remove sitemap post limit and add blacklist for events

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -66,7 +66,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       const [postsEn, postsEs] = await Promise.all([
         fetchNostrPosts(
           settings.ownerNpub,
-          settings.maxPosts || 50,
+          undefined,
           "en",
           {
             noteIds: settings.noteEventIds,
@@ -75,7 +75,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         ),
         fetchNostrPosts(
           settings.ownerNpub,
-          settings.maxPosts || 50,
+          undefined,
           "es",
           {
             noteIds: settings.noteEventIds,
@@ -83,8 +83,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           },
         ),
       ])
-      const esMap = new Map(postsEs.map((p) => [p.id, p]))
-      postsEn.forEach((post) => {
+      const blacklist = new Set(settings.blacklistEventIds || [])
+      const filteredEn = postsEn.filter((p) => !blacklist.has(p.id))
+      const filteredEs = postsEs.filter((p) => !blacklist.has(p.id))
+      const esMap = new Map(filteredEs.map((p) => [p.id, p]))
+      filteredEn.forEach((post) => {
         const lastModified = new Date((post.published_at || post.created_at) * 1000)
         routes.push({
           url: `${siteUrl}/blog/${post.id}`,
@@ -94,7 +97,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
             : {}),
         })
       })
-      postsEs.forEach((post) => {
+      filteredEs.forEach((post) => {
         routes.push({
           url: `${siteUrl}/es/blog/${post.id}`,
           lastModified: new Date((post.published_at || post.created_at) * 1000),

--- a/lib/nostr-settings.ts
+++ b/lib/nostr-settings.ts
@@ -3,6 +3,7 @@ export interface NostrSettings {
   relays: string[];
   noteEventIds: string[];
   articleEventIds: string[];
+  blacklistEventIds: string[];
   maxPosts: number;
   enableComments: boolean;
   enableViews: boolean;

--- a/settings.json
+++ b/settings.json
@@ -16,6 +16,9 @@
     "relays": ["wss://relay.damus.io", "wss://relay.snort.social", "wss://nostr.wine"],
     "noteEventIds": [],
     "articleEventIds": [],
+    "blacklistEventIds": [
+      "a7e85bf8eb7c7c811eb049b17a64d0ae69282ce2eebabb3aa3035223be56edb3"
+    ],
     "maxPosts": 10,
     "enableComments": true,
     "enableViews": true


### PR DESCRIPTION
## Summary
- remove maxPosts limit when generating sitemap
- allow blacklisting Nostr event IDs via settings
- support optional limit in `fetchNostrPosts`
- blacklist event `a7e85bf8eb7c7c811eb049b17a64d0ae69282ce2eebabb3aa3035223be56edb3`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68939d83a7e48326991249eccbd87ec9