### PR TITLE
fix spanish garden title

### DIFF
--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -21,9 +21,13 @@ export async function generateMetadata({
   params: { slug: string }
 }): Promise<Metadata> {
   const siteName = await getSiteName()
-  const gardenTitle = `${siteName}'s Garden`
   const cookieStore = cookies()
   const locale = (cookieStore.get('NEXT_LOCALE')?.value || 'en') as 'en' | 'es'
+  const t = getT(locale)
+  const gardenTitle =
+    locale === 'es'
+      ? `El ${t('navbar.garden')} de ${siteName}`
+      : `${siteName}'s ${t('navbar.garden')}`
   const note = await getNote(params.slug, locale)
   if (!note) {
     return { title: gardenTitle }

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -26,7 +26,10 @@ export async function generateMetadata(): Promise<Metadata> {
   const t = getT(locale)
   const siteUrl = getCanonicalUrl()
   const url = locale === 'es' ? `${siteUrl}/es/digital-garden` : `${siteUrl}/digital-garden`
-  const title = `${siteName}'s ${t('navbar.garden')}`
+  const title =
+    locale === 'es'
+      ? `El ${t('navbar.garden')} de ${siteName}`
+      : `${siteName}'s ${t('navbar.garden')}`
   return {
     title,
     alternates: {
@@ -67,7 +70,9 @@ export default async function DigitalGardenPage({
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="mb-8 text-center text-4xl font-bold">
-        {siteName}&apos;s {t('navbar.garden')}
+        {locale === 'es'
+          ? `El ${t('navbar.garden')} de ${siteName}`
+          : `${siteName}'s ${t('navbar.garden')}`}
       </h1>
       <div className="mb-4 text-center">
         <Link


### PR DESCRIPTION
## Summary
- localize digital garden titles for Spanish as 'El Jardín de {owner}'

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6893a5811a1c8326b7ab03bd1b2b7ce1