### PR TITLE
feat: localize blog metadata

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -73,15 +73,28 @@ export async function generateMetadata({
       locale === "es" && post.translation
         ? `${siteUrl}/es/blog/${post.id}`
         : `${siteUrl}/blog/${post.id}`
+    const languageAlternates = post.translation
+      ? {
+          en: `${siteUrl}/blog/${post.id}`,
+          es: `${siteUrl}/es/blog/${post.id}`,
+        }
+      : {
+          en: `${siteUrl}/blog/${post.id}`,
+        }
+    const ogLocale = locale === "es" ? "es_ES" : "en_US"
     return {
       title,
       description,
-      alternates: { canonical: url },
+      alternates: { canonical: url, languages: languageAlternates },
       openGraph: {
         title,
         description,
         url,
         type: "article",
+        locale: ogLocale,
+        ...(post.translation
+          ? { alternateLocale: ogLocale === "es_ES" ? ["en_US"] : ["es_ES"] }
+          : {}),
       },
     }
   } catch {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -17,14 +17,23 @@ export async function generateMetadata(): Promise<Metadata> {
   const title = `${t.title || "Blog"} - ${siteName}`
   const description = t.subtitle as string | undefined
   const image = "/profile-picture.png"
+  const ogLocale = locale === "es" ? "es_ES" : "en_US"
   return {
     title,
     description,
-    alternates: { canonical: url },
+    alternates: {
+      canonical: url,
+      languages: {
+        en: `${siteUrl}/blog`,
+        es: `${siteUrl}/es/blog`,
+      },
+    },
     openGraph: {
       title,
       description,
       url,
+      locale: ogLocale,
+      alternateLocale: ogLocale === "es_ES" ? ["en_US"] : ["es_ES"],
       images: [
         { url: image, width: 1200, height: 630, alt: title },
       ],


### PR DESCRIPTION
## Summary
- add language alternate URLs and OpenGraph locale to blog index metadata
- ensure individual blog posts expose language alternates and locale-specific OpenGraph data

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6893a7f213588326ad06813d2d7e06e8