### PR TITLE
feat: add localized projects metadata

### DIFF
--- a/app/projects/layout.tsx
+++ b/app/projects/layout.tsx
@@ -1,0 +1,45 @@
+import type React from "react"
+import type { Metadata } from "next"
+import { cookies } from "next/headers"
+import { getCanonicalUrl } from "@/utils/getCanonicalUrl"
+import en from "@/locales/en.json"
+import es from "@/locales/es.json"
+
+export const revalidate = 60 * 60 * 24
+
+const translations = { en, es } as const
+
+export async function generateMetadata(): Promise<Metadata> {
+  const cookieStore = cookies()
+  const locale = (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es") || "en"
+  const dict = translations[locale]
+  const siteUrl = getCanonicalUrl()
+  const url = locale === "es" ? `${siteUrl}/es/projects` : `${siteUrl}/projects`
+  const title = dict.projects.metadata.title
+  const description = dict.projects.metadata.description
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+      languages: {
+        en: `${siteUrl}/projects`,
+        es: `${siteUrl}/es/projects`,
+      },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+    },
+    twitter: {
+      title,
+      description,
+    },
+  }
+}
+
+export default function ProjectsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -73,6 +73,10 @@
   "projects": {
     "title": "{{ownerName}}'s projects",
     "subtitle": "A collection of my work, showcasing various technologies and problem-solving approaches.",
+    "metadata": {
+      "title": "Fabricio's Projects",
+      "description": "A collection of my work, showcasing various technologies and problem-solving approaches"
+    },
     "github": "GitHub",
     "live_demo": "Live Demo",
     "no_projects": "No projects to display yet. Check back soon!",

--- a/locales/es.json
+++ b/locales/es.json
@@ -73,6 +73,10 @@
   "projects": {
     "title": "Proyectos de {{ownerName}}",
     "subtitle": "Una colección de mi trabajo, que muestra diversas tecnologías y enfoques para resolver problemas.",
+    "metadata": {
+      "title": "Proyectos de Fabricio",
+      "description": "Una colección de mi trabajo, que muestra diversas tecnologías y enfoques para resolver problemas."
+    },
     "github": "GitHub",
     "live_demo": "Demo en vivo",
     "no_projects": "No hay proyectos para mostrar todavía. ¡Vuelve pronto!",


### PR DESCRIPTION
## Summary
- localize projects page metadata via new layout
- translate metadata strings into English and Spanish

## Testing
- `pnpm lint`
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_6893b6aed2108326a03c5b5c580da78e