### PR TITLE
feat: add share as story image generator

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Search, FileText, MessageSquare, Calendar, RefreshCw } from "lucide-react"
+import ShareStoryButton from "@/components/share-story-button"
 import { fetchNostrPosts } from "@/lib/nostr"
 import { getNostrSettings } from "@/lib/nostr-settings"
 import Link from "next/link"
@@ -269,6 +270,11 @@ export default function BlogPage() {
           ) : (
             visiblePosts.map((post) => {
               const imageUrl = post.image || extractImageUrl(post.content)
+              const tagline =
+                post.summary ||
+                post.content.split("\n").find((l) => l.trim()) || ""
+              const titleText =
+                post.title || truncateContent(post.content, 60)
               return (
                 <Link
                   key={post.id}
@@ -291,7 +297,7 @@ export default function BlogPage() {
                       />
                     )}
                     <CardHeader>
-                      <div className="flex items-center justify-between mb-2">
+                      <div className="mb-2 flex items-center justify-between">
                         <Badge
                           variant="secondary"
                           className={cn(
@@ -333,11 +339,16 @@ export default function BlogPage() {
                       )}
                     </CardHeader>
                     <CardContent>
-                      <div className="prose prose-slate dark:prose-invert max-w-none w-full break-words">
+                      <div className="prose prose-slate dark:prose-invert w-full max-w-none break-words">
                         <p className="text-slate-700 dark:text-slate-300 leading-relaxed break-all overflow-hidden line-clamp-3">
                           {truncateContent(post.content)}
                         </p>
                       </div>
+                      <ShareStoryButton
+                        title={titleText}
+                        tagline={tagline}
+                        className="mt-4"
+                      />
                     </CardContent>
                   </Card>
                 </Link>

--- a/components/digital-garden-list.tsx
+++ b/components/digital-garden-list.tsx
@@ -5,12 +5,14 @@ import { useState } from "react"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import ShareStoryButton from "@/components/share-story-button"
 import { useI18n } from "@/components/locale-provider"
 
 interface Note {
   slug: string
   title: string
   tags: string[]
+  content: string
 }
 
 export default function DigitalGardenList({
@@ -27,38 +29,43 @@ export default function DigitalGardenList({
   return (
     <>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {visibleNotes.map((note) => (
-          <Link
-            key={note.slug}
-            href={
-              locale === "es"
-                ? `/es/digital-garden/${note.slug}`
-                : `/digital-garden/${note.slug}`
-            }
-            className="block"
-          >
-            <Card className="h-full transition-colors hover:bg-muted">
-              <CardHeader>
-                <CardTitle>{note.title}</CardTitle>
-              </CardHeader>
-              {note.tags.length > 0 && (
-                <CardContent className="pt-0">
-                  <div className="flex flex-wrap gap-2">
-                    {note.tags.map((tag) => (
-                      <Badge
-                        key={tag}
-                        variant="secondary"
-                        className="bg-green-100 text-green-700"
-                      >
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
+        {visibleNotes.map((note) => {
+          const firstLine =
+            note.content.split("\n").find((l) => l.trim()) || ""
+          return (
+            <Link
+              key={note.slug}
+              href={
+                locale === "es"
+                  ? `/es/digital-garden/${note.slug}`
+                  : `/digital-garden/${note.slug}`
+              }
+              className="block"
+            >
+              <Card className="h-full transition-colors hover:bg-muted">
+                <CardHeader>
+                  <CardTitle>{note.title}</CardTitle>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-2 pt-0">
+                  {note.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {note.tags.map((tag) => (
+                        <Badge
+                          key={tag}
+                          variant="secondary"
+                          className="bg-green-100 text-green-700"
+                        >
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                  <ShareStoryButton title={note.title} tagline={firstLine} />
                 </CardContent>
-              )}
-            </Card>
-          </Link>
-        ))}
+              </Card>
+            </Link>
+          )
+        })}
       </div>
       {visibleCount < notes.length && (
         <div className="mt-6 flex justify-center">

--- a/components/share-story-button.tsx
+++ b/components/share-story-button.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Share2 } from "lucide-react"
+import { generateStoryImage } from "@/lib/share-story"
+import { useI18n } from "@/components/locale-provider"
+
+interface Props {
+  title: string
+  tagline: string
+  className?: string
+}
+
+export default function ShareStoryButton({ title, tagline, className }: Props) {
+  const { t } = useI18n()
+
+  const handleClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    await generateStoryImage({ title, tagline })
+  }
+
+  return (
+    <Button
+      onClick={handleClick}
+      size="sm"
+      variant="outline"
+      className={className}
+    >
+      <Share2 className="mr-2 h-4 w-4" />
+      {t("share_story")}
+    </Button>
+  )
+}

--- a/lib/share-story.ts
+++ b/lib/share-story.ts
@@ -1,0 +1,54 @@
+'use client'
+
+import { toPng } from 'html-to-image'
+
+export async function generateStoryImage({
+  title,
+  tagline,
+}: {
+  title: string
+  tagline: string
+}) {
+  const container = document.createElement('div')
+  container.style.width = '1080px'
+  container.style.height = '1920px'
+  container.style.display = 'flex'
+  container.style.flexDirection = 'column'
+  container.style.justifyContent = 'center'
+  container.style.alignItems = 'center'
+  container.style.backgroundColor = '#ffffff'
+  container.style.padding = '80px'
+  container.style.fontFamily = 'system-ui, sans-serif'
+  container.style.position = 'relative'
+  container.style.textAlign = 'center'
+
+  const titleEl = document.createElement('div')
+  titleEl.textContent = title
+  titleEl.style.fontSize = '64px'
+  titleEl.style.fontWeight = 'bold'
+  titleEl.style.marginBottom = '40px'
+  container.appendChild(titleEl)
+
+  const taglineEl = document.createElement('div')
+  taglineEl.textContent = tagline
+  taglineEl.style.fontSize = '48px'
+  container.appendChild(taglineEl)
+
+  const brandingEl = document.createElement('div')
+  brandingEl.textContent = '🧘 Fabricio'
+  brandingEl.style.position = 'absolute'
+  brandingEl.style.bottom = '80px'
+  brandingEl.style.left = '50%'
+  brandingEl.style.transform = 'translateX(-50%)'
+  brandingEl.style.fontSize = '48px'
+  container.appendChild(brandingEl)
+
+  document.body.appendChild(container)
+  const dataUrl = await toPng(container)
+  document.body.removeChild(container)
+
+  const link = document.createElement('a')
+  link.download = `${title}.png`
+  link.href = dataUrl
+  link.click()
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -98,5 +98,6 @@
     "garden_graph": "Garden Graph",
     "back": "\u2190 Back to Garden"
   },
-  "show_more": "Show more"
+  "show_more": "Show more",
+  "share_story": "Share as Story"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -98,5 +98,6 @@
     "garden_graph": "Grafo del Jardín",
     "back": "\u2190 Volver al Jardín"
   },
-  "show_more": "Mostrar más"
+  "show_more": "Mostrar más",
+  "share_story": "Compartir como historia"
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "d3": "latest",
     "embla-carousel-react": "latest",
     "gray-matter": "^4.0.3",
+    "html-to-image": "^1.11.13",
     "input-otp": "latest",
     "lucide-react": "^0.454.0",
     "marked": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       input-otp:
         specifier: latest
         version: 1.4.2(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
@@ -2131,6 +2134,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -5300,6 +5306,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  html-to-image@1.11.13: {}
 
   iconv-lite@0.6.3:
     dependencies:


### PR DESCRIPTION
## Summary
- allow cards to be shared as Instagram-style stories
- generate branded PNG images with title and summary
- localize "Share as Story" button text in English and Spanish

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6893d61294688326ae94182fbf6a626d