### PR TITLE
feat: handle missing garden notes

### DIFF
--- a/components/MissingNote.tsx
+++ b/components/MissingNote.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+
+interface MissingNoteProps {
+  slug: string
+  locale: 'en' | 'es'
+}
+
+export default function MissingNote({ slug, locale }: MissingNoteProps) {
+  const base = locale === 'es' ? '/es/digital-garden' : '/digital-garden'
+  const title = slug.replace(/-/g, ' ')
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-8">
+      <article className="prose dark:prose-invert">
+        <h1>{title}</h1>
+        <p>This note has not been created yet.</p>
+        <Link href={base} className="text-blue-600 hover:underline">
+          Back to the garden
+        </Link>
+      </article>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show a friendly missing note component when a garden entry is absent
- mark nonexistent wiki links and prevent them from generating links
- add robots `noindex,follow` metadata for missing notes

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6893e17debe48326b80f9e6ead9f5936