### PR TITLE
feat: add local graph to digital garden notes

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -96,6 +96,7 @@
     "graph_view": "Graph View",
     "all": "All",
     "garden_graph": "Garden Graph",
+    "local_graph": "Local Graph",
     "back": "\u2190 Back to Garden"
   },
   "show_more": "Show more"

--- a/locales/es.json
+++ b/locales/es.json
@@ -96,6 +96,7 @@
     "graph_view": "Vista de Grafo",
     "all": "Todo",
     "garden_graph": "Grafo del Jardín",
+    "local_graph": "Grafo Local",
     "back": "\u2190 Volver al Jardín"
   },
   "show_more": "Mostrar más"


### PR DESCRIPTION
## Summary
- add local graph visualization to each digital garden note page
- provide translations for new section in English and Spanish

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6894f42347dc83269d4ceeae834bc03a