### PR TITLE
style: enhance digital garden graph visuals

### DIFF
--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { marked } from 'marked'
 import { getAllNotes, getNote } from '@/lib/digital-garden'
 import { getSiteName } from '@/lib/settings'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { slugify } from '@/lib/slugify'
 import MissingNote from '@/components/MissingNote'
 import en from '@/locales/en.json'
@@ -119,13 +120,12 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
         )}
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </article>
-      <div className="mt-8">
-        <Link
-          href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}
-          className="text-blue-600 hover:underline"
-        >
-          {t('digital_garden.back')}
-        </Link>
+      <div className="mt-8 flex justify-center">
+        <Button asChild variant="outline">
+          <Link href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}>
+            {t('digital_garden.back')}
+          </Link>
+        </Button>
       </div>
     </div>
   )

--- a/app/digital-garden/graph/page.tsx
+++ b/app/digital-garden/graph/page.tsx
@@ -1,5 +1,6 @@
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
+import { Button } from '@/components/ui/button'
 import { cookies } from 'next/headers'
 import { getAllNotes } from '@/lib/digital-garden'
 import { slugify } from '@/lib/slugify'
@@ -35,13 +36,12 @@ export default async function DigitalGardenGraphPage() {
     <div className="container mx-auto px-4 py-8">
       <h1 className="mb-4 text-center text-3xl font-bold">{t('digital_garden.garden_graph')}</h1>
       <WikiGraph data={{ nodes, links }} />
-      <div className="mt-4 text-center">
-        <Link
-          href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}
-          className="text-blue-600 hover:underline"
-        >
-          {t('digital_garden.back')}
-        </Link>
+      <div className="mt-4 flex justify-center">
+        <Button asChild variant="outline">
+          <Link href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}>
+            {t('digital_garden.back')}
+          </Link>
+        </Button>
       </div>
     </div>
   )

--- a/components/wiki-graph.tsx
+++ b/components/wiki-graph.tsx
@@ -25,6 +25,7 @@ export default function WikiGraph({ data }: { data: GraphData }) {
     const isDark = resolvedTheme === 'dark'
     const linkColor = isDark ? '#555' : '#999'
     const nodeColor = isDark ? '#60a5fa' : '#1f77b4'
+    const highlightColor = isDark ? '#93c5fd' : '#3b82f6'
     const textColor = isDark ? '#fff' : '#000'
 
     const simulation = d3
@@ -39,6 +40,7 @@ export default function WikiGraph({ data }: { data: GraphData }) {
     const link = svg
       .append('g')
       .attr('stroke', linkColor)
+      .attr('stroke-width', 1.5)
       .attr('stroke-opacity', 0.6)
       .selectAll('line')
       .data(data.links)
@@ -53,8 +55,15 @@ export default function WikiGraph({ data }: { data: GraphData }) {
       .data(data.nodes)
       .enter()
       .append('circle')
-      .attr('r', 8)
+      .attr('r', 10)
       .attr('fill', nodeColor)
+      .style('cursor', 'pointer')
+      .on('mouseover', function () {
+        d3.select(this).attr('fill', highlightColor)
+      })
+      .on('mouseout', function () {
+        d3.select(this).attr('fill', nodeColor)
+      })
       .on('click', (_event, d: any) => {
         const base = locale === 'es' ? '/es/digital-garden' : '/digital-garden'
         window.location.href = `${base}/${d.id}`
@@ -109,5 +118,5 @@ export default function WikiGraph({ data }: { data: GraphData }) {
     }
   }, [data, resolvedTheme, locale])
 
-  return <svg ref={ref} className="h-[600px] w-full"></svg>
+  return <svg ref={ref} className="h-[600px] w-full rounded-lg border bg-card"></svg>
 }


### PR DESCRIPTION
## Summary
- restyle wiki graph nodes and links for improved interaction
- convert graph back link to a styled button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894f3d872508326b7423581b5e87112