### PR TITLE
Use English 'Garden' label in Spanish navbar

### DIFF
--- a/locales/es.json
+++ b/locales/es.json
@@ -5,7 +5,7 @@
     "projects": "Proyectos",
     "resume": "Currículum",
     "lifestyle": "Estilo de vida",
-    "garden": "Jardín",
+    "garden": "Garden",
     "contact": "Contacto",
     "open_menu": "Abrir menú",
     "close_menu": "Cerrar menú"


### PR DESCRIPTION
## Summary
- change Spanish navbar `garden` translation to `Garden`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6894f7edbd688326986bde3cfa31ef27