### PR TITLE
feat: add digital garden preview image

### DIFF
--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -57,10 +57,12 @@ export async function generateMetadata({
       description,
       url,
       type: 'article',
+      images: ['/digital-garden.png'],
     },
     twitter: {
       title,
       description,
+      images: ['/digital-garden.png'],
     },
   }
 }


### PR DESCRIPTION
## Summary
- use `digital-garden.png` as open graph and twitter image for digital garden notes and graph

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689500d8d65c8326adc976095013c55c