### PR TITLE
Enhance graph interaction and back navigation

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -179,13 +179,14 @@ export default async function BlogPostPage({
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
         <div className="container mx-auto px-4 py-8">
           <div className="mb-4">
-            <Link
-              href={locale === "es" ? "/es/blog" : "/blog"}
-              className="text-blue-600 hover:underline"
-              prefetch={false}
-            >
-              ← Back to Blog
-            </Link>
+            <Button asChild variant="outline" size="sm">
+              <Link
+                href={locale === "es" ? "/es/blog" : "/blog"}
+                prefetch={false}
+              >
+                {locale === "es" ? "← Volver al Blog" : "← Back to Blog"}
+              </Link>
+            </Button>
           </div>
           <Card className="mx-auto max-w-3xl border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm break-words">
             {post.image && (

--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { marked } from 'marked'
 import { getAllNotes, getNote } from '@/lib/digital-garden'
 import { getSiteName } from '@/lib/settings'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { slugify } from '@/lib/slugify'
 import MissingNote from '@/components/MissingNote'
 import en from '@/locales/en.json'
@@ -122,12 +123,11 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </article>
       <div className="mt-8">
-        <Link
-          href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}
-          className="text-blue-600 hover:underline"
-        >
-          {t('digital_garden.back')}
-        </Link>
+        <Button asChild variant="outline">
+          <Link href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}>
+            {t('digital_garden.back')}
+          </Link>
+        </Button>
       </div>
     </div>
   )

--- a/app/digital-garden/graph/page.tsx
+++ b/app/digital-garden/graph/page.tsx
@@ -1,5 +1,6 @@
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
+import { Button } from '@/components/ui/button'
 import { cookies, headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { getAllNotes } from '@/lib/digital-garden'
@@ -76,13 +77,12 @@ export default async function DigitalGardenGraphPage() {
     <div className="container mx-auto px-4 py-8">
       <h1 className="mb-4 text-center text-3xl font-bold">{t('digital_garden.garden_graph')}</h1>
       <WikiGraph data={{ nodes, links }} />
-      <div className="mt-4 text-center">
-        <Link
-          href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}
-          className="text-blue-600 hover:underline"
-        >
-          {t('digital_garden.back')}
-        </Link>
+      <div className="mt-4 flex justify-center">
+        <Button asChild variant="outline">
+          <Link href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}>
+            {t('digital_garden.back')}
+          </Link>
+        </Button>
       </div>
     </div>
   )

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -1,10 +1,12 @@
 import { notFound } from "next/navigation"
 import { cookies } from "next/headers"
+import Link from "next/link"
 import fs from "fs/promises"
 import path from "path"
 import { marked } from "marked"
 import matter from "gray-matter"
 import type { Metadata } from "next"
+import { Button } from "@/components/ui/button"
 import { getSettings } from "@/lib/settings"
 import en from "@/locales/en.json"
 import es from "@/locales/es.json"
@@ -103,6 +105,13 @@ export default async function ProjectPage({ params }: { params: { slug: string }
         )}
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </article>
+      <div className="mt-8">
+        <Button asChild variant="outline">
+          <Link href={locale === "es" ? "/es/projects" : "/projects"}>
+            {locale === "es" ? "← Volver a Proyectos" : "← Back to Projects"}
+          </Link>
+        </Button>
+      </div>
     </div>
   )
 }

--- a/components/wiki-graph.tsx
+++ b/components/wiki-graph.tsx
@@ -26,6 +26,7 @@ export default function WikiGraph({ data }: { data: GraphData }) {
     const linkColor = isDark ? '#555' : '#999'
     const nodeColor = isDark ? '#60a5fa' : '#1f77b4'
     const textColor = isDark ? '#fff' : '#000'
+    const highlightColor = isDark ? '#fbbf24' : '#d97706'
 
     const simulation = d3
       .forceSimulation(data.nodes as any)
@@ -44,6 +45,7 @@ export default function WikiGraph({ data }: { data: GraphData }) {
       .data(data.links)
       .enter()
       .append('line')
+      .attr('stroke-width', 1.5)
 
     const node = svg
       .append('g')
@@ -53,8 +55,9 @@ export default function WikiGraph({ data }: { data: GraphData }) {
       .data(data.nodes)
       .enter()
       .append('circle')
-      .attr('r', 8)
+      .attr('r', 10)
       .attr('fill', nodeColor)
+      .style('cursor', 'pointer')
 
     const label = svg
       .append('g')
@@ -63,31 +66,48 @@ export default function WikiGraph({ data }: { data: GraphData }) {
       .enter()
       .append('text')
       .text((d) => d.title)
-      .attr('font-size', 10)
+      .attr('font-size', 12)
       .attr('dx', 12)
       .attr('dy', '0.35em')
       .attr('fill', textColor)
+      .style('cursor', 'pointer')
       .on('mouseover', (event, d: any) => {
         node
           .filter((n: any) => n.id === d.id)
           .transition()
           .duration(200)
-          .attr('r', 12)
+          .attr('r', 14)
+        link
+          .filter(
+            (l: any) => l.source.id === d.id || l.target.id === d.id,
+          )
+          .transition()
+          .duration(200)
+          .attr('stroke', highlightColor)
+          .attr('stroke-width', 2.5)
         d3.select(event.currentTarget)
           .transition()
           .duration(200)
-          .attr('font-size', 14)
+          .attr('font-size', 16)
       })
       .on('mouseout', (event, d: any) => {
         node
           .filter((n: any) => n.id === d.id)
           .transition()
           .duration(200)
-          .attr('r', 8)
+          .attr('r', 10)
+        link
+          .filter(
+            (l: any) => l.source.id === d.id || l.target.id === d.id,
+          )
+          .transition()
+          .duration(200)
+          .attr('stroke', linkColor)
+          .attr('stroke-width', 1.5)
         d3.select(event.currentTarget)
           .transition()
           .duration(200)
-          .attr('font-size', 10)
+          .attr('font-size', 12)
       })
 
     node
@@ -99,23 +119,39 @@ export default function WikiGraph({ data }: { data: GraphData }) {
         d3.select(event.currentTarget)
           .transition()
           .duration(200)
-          .attr('r', 12)
+          .attr('r', 14)
         label
           .filter((l: any) => l.id === d.id)
           .transition()
           .duration(200)
-          .attr('font-size', 14)
+          .attr('font-size', 16)
+        link
+          .filter(
+            (l: any) => l.source.id === d.id || l.target.id === d.id,
+          )
+          .transition()
+          .duration(200)
+          .attr('stroke', highlightColor)
+          .attr('stroke-width', 2.5)
       })
       .on('mouseout', (event, d: any) => {
         d3.select(event.currentTarget)
           .transition()
           .duration(200)
-          .attr('r', 8)
+          .attr('r', 10)
         label
           .filter((l: any) => l.id === d.id)
           .transition()
           .duration(200)
-          .attr('font-size', 10)
+          .attr('font-size', 12)
+        link
+          .filter(
+            (l: any) => l.source.id === d.id || l.target.id === d.id,
+          )
+          .transition()
+          .duration(200)
+          .attr('stroke', linkColor)
+          .attr('stroke-width', 1.5)
       })
       .call(
         d3


### PR DESCRIPTION
## Summary
- restyle wiki graph nodes, links and hover behavior for improved interaction
- convert digital garden graph and note back links to buttons
- add styled back buttons for blog posts and project pages

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689506b7e9e483268f9e85a58f39a8fc