### PR TITLE
feat: add graph settings panel

### DIFF
--- a/app/digital-garden/graph/page.tsx
+++ b/app/digital-garden/graph/page.tsx
@@ -54,13 +54,13 @@ function getT(locale: keyof typeof translations) {
     key.split('.').reduce((o: any, k) => (o ? o[k] : undefined), translations[locale]) || key
 }
 
-const WikiGraph = dynamic(() => import('@/components/wiki-graph'), { ssr: false })
+const GraphWithSettings = dynamic(() => import('@/components/graph-with-settings'), { ssr: false })
 
 export default async function DigitalGardenGraphPage() {
   const locale = (cookies().get('NEXT_LOCALE')?.value || 'en') as 'en' | 'es'
   const t = getT(locale)
   const notes = await getAllNotes(locale)
-  const nodes = notes.map((n) => ({ id: n.slug, title: n.title }))
+  const nodes = notes.map((n) => ({ id: n.slug, title: n.title, tags: n.tags }))
   const links: { source: string; target: string }[] = []
   const linkRegex = /\[\[([^\]]+)\]\]/g
   for (const note of notes) {
@@ -72,10 +72,11 @@ export default async function DigitalGardenGraphPage() {
       }
     }
   }
+  const allTags = Array.from(new Set(notes.flatMap((n) => n.tags))).sort()
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="mb-4 text-center text-3xl font-bold">{t('digital_garden.garden_graph')}</h1>
-      <WikiGraph data={{ nodes, links }} />
+      <GraphWithSettings data={{ nodes, links }} tags={allTags} />
       <div className="mt-4 text-center">
         <Link
           href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}

--- a/components/graph-with-settings.tsx
+++ b/components/graph-with-settings.tsx
@@ -1,0 +1,230 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import WikiGraph from '@/components/wiki-graph'
+import { Button } from '@/components/ui/button'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet'
+import { Slider } from '@/components/ui/slider'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
+import { Checkbox } from '@/components/ui/checkbox'
+import { useI18n } from '@/components/locale-provider'
+
+interface GraphData {
+  nodes: { id: string; title: string; tags: string[] }[]
+  links: { source: string; target: string }[]
+}
+
+interface Settings {
+  showArrows: boolean
+  textFadeThreshold: number
+  nodeSize: number
+  linkWidth: number
+  centerForce: number
+  chargeForce: number
+  linkForce: number
+  linkDistance: number
+  tagColors: Record<string, string>
+  hiddenTags: string[]
+}
+
+const defaultSettings: Settings = {
+  showArrows: false,
+  textFadeThreshold: 1,
+  nodeSize: 8,
+  linkWidth: 1,
+  centerForce: 0.1,
+  chargeForce: -200,
+  linkForce: 1,
+  linkDistance: 100,
+  tagColors: {},
+  hiddenTags: [],
+}
+
+export default function GraphWithSettings({
+  data,
+  tags,
+}: {
+  data: GraphData
+  tags: string[]
+}) {
+  const [settings, setSettings] = useState<Settings>(defaultSettings)
+  const [refresh, setRefresh] = useState(0)
+  const { t } = useI18n()
+
+  useEffect(() => {
+    const stored = localStorage.getItem('graphSettings')
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        setSettings((s) => ({ ...s, ...parsed }))
+      } catch {}
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('graphSettings', JSON.stringify(settings))
+  }, [settings])
+
+  return (
+    <div>
+      <div className="mb-4 flex justify-end">
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant="outline">{t('digital_garden.settings')}</Button>
+          </SheetTrigger>
+          <SheetContent className="overflow-y-auto">
+            <SheetHeader>
+              <SheetTitle>{t('digital_garden.graph_settings')}</SheetTitle>
+            </SheetHeader>
+            <div className="mt-4 space-y-6">
+              <div className="flex items-center justify-between">
+                <Label>{t('digital_garden.show_arrows')}</Label>
+                <Switch
+                  checked={settings.showArrows}
+                  onCheckedChange={(checked) =>
+                    setSettings((s) => ({ ...s, showArrows: checked }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>{t('digital_garden.text_fade')}</Label>
+                <Slider
+                  value={[settings.textFadeThreshold]}
+                  min={0}
+                  max={3}
+                  step={0.1}
+                  onValueChange={([v]) =>
+                    setSettings((s) => ({ ...s, textFadeThreshold: v }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>{t('digital_garden.node_size')}</Label>
+                <Slider
+                  value={[settings.nodeSize]}
+                  min={4}
+                  max={20}
+                  step={1}
+                  onValueChange={([v]) =>
+                    setSettings((s) => ({ ...s, nodeSize: v }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>{t('digital_garden.link_thickness')}</Label>
+                <Slider
+                  value={[settings.linkWidth]}
+                  min={1}
+                  max={10}
+                  step={1}
+                  onValueChange={([v]) =>
+                    setSettings((s) => ({ ...s, linkWidth: v }))
+                  }
+                />
+              </div>
+              <div className="flex justify-between">
+                <Button
+                  variant="outline"
+                  onClick={() => setRefresh((r) => r + 1)}
+                >
+                  {t('digital_garden.animate')}
+                </Button>
+              </div>
+              <div className="space-y-2">
+                <Label>{t('digital_garden.center_force')}</Label>
+                <Slider
+                  value={[settings.centerForce]}
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  onValueChange={([v]) =>
+                    setSettings((s) => ({ ...s, centerForce: v }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>{t('digital_garden.repel_force')}</Label>
+                <Slider
+                  value={[settings.chargeForce]}
+                  min={-500}
+                  max={0}
+                  step={10}
+                  onValueChange={([v]) =>
+                    setSettings((s) => ({ ...s, chargeForce: v }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>{t('digital_garden.link_force')}</Label>
+                <Slider
+                  value={[settings.linkForce]}
+                  min={0}
+                  max={2}
+                  step={0.1}
+                  onValueChange={([v]) =>
+                    setSettings((s) => ({ ...s, linkForce: v }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>{t('digital_garden.link_distance')}</Label>
+                <Slider
+                  value={[settings.linkDistance]}
+                  min={20}
+                  max={300}
+                  step={10}
+                  onValueChange={([v]) =>
+                    setSettings((s) => ({ ...s, linkDistance: v }))
+                  }
+                />
+              </div>
+              <div className="space-y-4">
+                <Label>{t('digital_garden.tag_colors')}</Label>
+                {tags.map((tag) => (
+                  <div
+                    key={tag}
+                    className="flex items-center justify-between space-x-2"
+                  >
+                    <Input
+                      type="color"
+                      value={settings.tagColors[tag] || '#1f77b4'}
+                      className="h-8 w-8 p-1"
+                      onChange={(e) =>
+                        setSettings((s) => ({
+                          ...s,
+                          tagColors: { ...s.tagColors, [tag]: e.target.value },
+                        }))
+                      }
+                    />
+                    <span className="flex-1 text-sm">{tag}</span>
+                    <Checkbox
+                      checked={!settings.hiddenTags.includes(tag)}
+                      onCheckedChange={(checked) =>
+                        setSettings((s) => ({
+                          ...s,
+                          hiddenTags: checked
+                            ? s.hiddenTags.filter((t) => t !== tag)
+                            : [...s.hiddenTags, tag],
+                        }))
+                      }
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+      <WikiGraph key={refresh} data={data} settings={settings} />
+    </div>
+  )
+}
+

--- a/components/wiki-graph.tsx
+++ b/components/wiki-graph.tsx
@@ -6,11 +6,30 @@ import { useTheme } from 'next-themes'
 import * as d3 from 'd3'
 
 interface GraphData {
-  nodes: { id: string; title: string }[]
+  nodes: { id: string; title: string; tags: string[] }[]
   links: { source: string; target: string }[]
 }
 
-export default function WikiGraph({ data }: { data: GraphData }) {
+interface Settings {
+  showArrows: boolean
+  textFadeThreshold: number
+  nodeSize: number
+  linkWidth: number
+  centerForce: number
+  chargeForce: number
+  linkForce: number
+  linkDistance: number
+  tagColors: Record<string, string>
+  hiddenTags: string[]
+}
+
+export default function WikiGraph({
+  data,
+  settings,
+}: {
+  data: GraphData
+  settings: Settings
+}) {
   const ref = useRef<SVGSVGElement>(null)
   const { resolvedTheme } = useTheme()
   const { locale } = useI18n()
@@ -24,42 +43,78 @@ export default function WikiGraph({ data }: { data: GraphData }) {
 
     const isDark = resolvedTheme === 'dark'
     const linkColor = isDark ? '#555' : '#999'
-    const nodeColor = isDark ? '#60a5fa' : '#1f77b4'
+    const nodeDefault = isDark ? '#60a5fa' : '#1f77b4'
     const textColor = isDark ? '#fff' : '#000'
 
+    const nodes = data.nodes.filter(
+      (n) => !settings.hiddenTags.some((t) => n.tags.includes(t)),
+    )
+    const nodeIds = new Set(nodes.map((n) => n.id))
+    const links = data.links.filter(
+      (l) => nodeIds.has(l.source) && nodeIds.has(l.target),
+    )
+
+    const g = svg.append('g')
+
+    if (settings.showArrows) {
+      svg
+        .append('defs')
+        .append('marker')
+        .attr('id', 'arrow')
+        .attr('viewBox', '0 -5 10 10')
+        .attr('refX', 10)
+        .attr('refY', 0)
+        .attr('markerWidth', 6)
+        .attr('markerHeight', 6)
+        .attr('orient', 'auto')
+        .append('path')
+        .attr('d', 'M0,-5L10,0L0,5')
+        .attr('fill', linkColor)
+    }
+
     const simulation = d3
-      .forceSimulation(data.nodes as any)
+      .forceSimulation(nodes as any)
       .force(
         'link',
-        d3.forceLink(data.links as any).id((d: any) => d.id).distance(100),
+        d3
+          .forceLink(links as any)
+          .id((d: any) => d.id)
+          .distance(settings.linkDistance)
+          .strength(settings.linkForce),
       )
-      .force('charge', d3.forceManyBody().strength(-200))
-      .force('center', d3.forceCenter(width / 2, height / 2))
+      .force('charge', d3.forceManyBody().strength(settings.chargeForce))
+      .force('x', d3.forceX(width / 2).strength(settings.centerForce))
+      .force('y', d3.forceY(height / 2).strength(settings.centerForce))
 
-    const link = svg
+    const link = g
       .append('g')
       .attr('stroke', linkColor)
       .attr('stroke-opacity', 0.6)
       .selectAll('line')
-      .data(data.links)
+      .data(links)
       .enter()
       .append('line')
+      .attr('stroke-width', settings.linkWidth)
 
-    const node = svg
+    if (settings.showArrows) {
+      link.attr('marker-end', 'url(#arrow)')
+    }
+
+    const node = g
       .append('g')
       .attr('stroke', '#fff')
       .attr('stroke-width', 1.5)
       .selectAll('circle')
-      .data(data.nodes)
+      .data(nodes)
       .enter()
       .append('circle')
-      .attr('r', 8)
-      .attr('fill', nodeColor)
+      .attr('r', settings.nodeSize)
+      .attr('fill', (d: any) => settings.tagColors[d.tags[0]] || nodeDefault)
 
-    const label = svg
+    const label = g
       .append('g')
       .selectAll('text')
-      .data(data.nodes)
+      .data(nodes)
       .enter()
       .append('text')
       .text((d) => d.title)
@@ -67,12 +122,28 @@ export default function WikiGraph({ data }: { data: GraphData }) {
       .attr('dx', 12)
       .attr('dy', '0.35em')
       .attr('fill', textColor)
+      .style('opacity', 1)
+
+    svg.call(
+      d3
+        .zoom<SVGSVGElement, unknown>()
+        .scaleExtent([0.1, 5])
+        .on('zoom', (event) => {
+          g.attr('transform', event.transform)
+          label.style(
+            'opacity',
+            event.transform.k >= settings.textFadeThreshold ? 1 : 0,
+          )
+        }),
+    )
+
+    label
       .on('mouseover', (event, d: any) => {
         node
           .filter((n: any) => n.id === d.id)
           .transition()
           .duration(200)
-          .attr('r', 12)
+          .attr('r', settings.nodeSize + 4)
         d3.select(event.currentTarget)
           .transition()
           .duration(200)
@@ -83,7 +154,7 @@ export default function WikiGraph({ data }: { data: GraphData }) {
           .filter((n: any) => n.id === d.id)
           .transition()
           .duration(200)
-          .attr('r', 8)
+          .attr('r', settings.nodeSize)
         d3.select(event.currentTarget)
           .transition()
           .duration(200)
@@ -99,7 +170,7 @@ export default function WikiGraph({ data }: { data: GraphData }) {
         d3.select(event.currentTarget)
           .transition()
           .duration(200)
-          .attr('r', 12)
+          .attr('r', settings.nodeSize + 4)
         label
           .filter((l: any) => l.id === d.id)
           .transition()
@@ -110,7 +181,7 @@ export default function WikiGraph({ data }: { data: GraphData }) {
         d3.select(event.currentTarget)
           .transition()
           .duration(200)
-          .attr('r', 8)
+          .attr('r', settings.nodeSize)
         label
           .filter((l: any) => l.id === d.id)
           .transition()
@@ -142,18 +213,15 @@ export default function WikiGraph({ data }: { data: GraphData }) {
         .attr('y1', (d: any) => (d.source as any).y)
         .attr('x2', (d: any) => (d.target as any).x)
         .attr('y2', (d: any) => (d.target as any).y)
-      node
-        .attr('cx', (d: any) => d.x)
-        .attr('cy', (d: any) => d.y)
-      label
-        .attr('x', (d: any) => d.x)
-        .attr('y', (d: any) => d.y)
+      node.attr('cx', (d: any) => d.x).attr('cy', (d: any) => d.y)
+      label.attr('x', (d: any) => d.x).attr('y', (d: any) => d.y)
     })
 
     return () => {
       simulation.stop()
     }
-  }, [data, resolvedTheme, locale])
+  }, [data, resolvedTheme, locale, settings])
 
   return <svg ref={ref} className="h-[600px] w-full"></svg>
 }
+

--- a/locales/en.json
+++ b/locales/en.json
@@ -96,7 +96,19 @@
     "graph_view": "Graph View",
     "all": "All",
     "garden_graph": "Garden Graph",
-    "back": "\u2190 Back to Garden"
+    "back": "\u2190 Back to Garden",
+    "settings": "Settings",
+    "graph_settings": "Graph Settings",
+    "show_arrows": "Show arrows",
+    "text_fade": "Text fade threshold",
+    "node_size": "Node size",
+    "link_thickness": "Link thickness",
+    "animate": "Animate",
+    "center_force": "Center force",
+    "repel_force": "Repel force",
+    "link_force": "Link force",
+    "link_distance": "Link distance",
+    "tag_colors": "Tag colors"
   },
   "show_more": "Show more"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -96,7 +96,19 @@
     "graph_view": "Vista de Grafo",
     "all": "Todo",
     "garden_graph": "Grafo del Jardín",
-    "back": "\u2190 Volver al Jardín"
+    "back": "\u2190 Volver al Jardín",
+    "settings": "Ajustes",
+    "graph_settings": "Configuración del Grafo",
+    "show_arrows": "Mostrar flechas",
+    "text_fade": "Umbral de desvanecimiento de texto",
+    "node_size": "Tamaño de nodo",
+    "link_thickness": "Grosor de enlace",
+    "animate": "Animar",
+    "center_force": "Fuerza central",
+    "repel_force": "Fuerza de repulsión",
+    "link_force": "Fuerza del enlace",
+    "link_distance": "Distancia del enlace",
+    "tag_colors": "Colores por etiqueta"
   },
   "show_more": "Mostrar más"
 }


### PR DESCRIPTION
## Summary
- add configurable graph settings panel for digital garden
- support node/link styling, force parameters, and tag color customization
- localize new settings UI

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68950600556c8326a8dfb31a13972dc8