### PR TITLE
Add OG type and Facebook app id for digital garden pages

### DIFF
--- a/app/digital-garden/graph/page.tsx
+++ b/app/digital-garden/graph/page.tsx
@@ -40,6 +40,7 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       url,
+      type: 'website',
       images: ['/digital-garden.png'],
     },
     twitter: {

--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -41,6 +41,7 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       url,
+      type: 'website',
       images: ['/digital-garden.png'],
     },
     twitter: {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -114,6 +114,9 @@ export async function generateMetadata(): Promise<Metadata> {
       description,
       images: [profileImage],
     },
+    other: {
+      'fb:app_id': process.env.NEXT_PUBLIC_FB_APP_ID,
+    },
   }
 }
 


### PR DESCRIPTION
## Summary
- specify og:type for digital garden pages
- include fb:app_id meta tag in global metadata

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6895097700088326a3a871cd40d91292