### PR TITLE
Add Facebook app ID to site metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -107,6 +107,7 @@ export async function generateMetadata(): Promise<Metadata> {
           alt: siteName,
         },
       ],
+      appId: settings.facebookAppId,
     },
     twitter: {
       card: "summary_large_image",

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -12,7 +12,7 @@ import matter from "gray-matter"
 export const revalidate = 60 * 60 * 24
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { siteName } = getSettings()
+  const { siteName, facebookAppId } = getSettings()
   const cookieStore = cookies()
   const locale = (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es") || "en"
   const dirPath = path.join(process.cwd(), "public", locale, "resume")
@@ -60,6 +60,7 @@ export async function generateMetadata(): Promise<Metadata> {
           alt: title,
         },
       ],
+      appId: facebookAppId,
     },
     twitter: {
       card: "summary_large_image",

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -3,6 +3,7 @@ export interface Settings {
   showLifestyle: boolean;
   siteName: string;
   siteDescription: string;
+  facebookAppId?: string;
   contactEmail: string;
   socialLinks: {
     twitter: string;

--- a/settings.json
+++ b/settings.json
@@ -4,6 +4,7 @@
     "showLifestyle": true,
     "siteName": "Fabricio Acosta",
     "siteDescription": "A personal blog powered by Nostr",
+    "facebookAppId": "1234567890",
     "contactEmail": "",
     "socialLinks": {
       "twitter": "",


### PR DESCRIPTION
## Summary
- add `facebookAppId` setting
- include the app ID in global Open Graph metadata
- ensure resume page Open Graph metadata includes the app ID

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689509a292cc832694c9f670cd81faf6