### PR TITLE
Enhance graph interaction and back navigation

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -179,13 +179,14 @@ export default async function BlogPostPage({
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800">
         <div className="container mx-auto px-4 py-8">
           <div className="mb-4">
-            <Link
-              href={locale === "es" ? "/es/blog" : "/blog"}
-              className="text-blue-600 hover:underline"
-              prefetch={false}
-            >
-              ← Back to Blog
-            </Link>
+            <Button asChild variant="outline">
+              <Link
+                href={locale === "es" ? "/es/blog" : "/blog"}
+                prefetch={false}
+              >
+                ← Back to Blog
+              </Link>
+            </Button>
           </div>
           <Card className="mx-auto max-w-3xl border-0 shadow-lg bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm break-words">
             {post.image && (

--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { Button } from '@/components/ui/button'
 import type { Metadata } from 'next'
 import { cookies, headers } from 'next/headers'
 import { marked } from 'marked'
@@ -122,12 +123,11 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </article>
       <div className="mt-8">
-        <Link
-          href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}
-          className="text-blue-600 hover:underline"
-        >
-          {t('digital_garden.back')}
-        </Link>
+        <Button asChild variant="outline">
+          <Link href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}>
+            {t('digital_garden.back')}
+          </Link>
+        </Button>
       </div>
     </div>
   )

--- a/app/digital-garden/graph/page.tsx
+++ b/app/digital-garden/graph/page.tsx
@@ -1,5 +1,6 @@
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
+import { Button } from '@/components/ui/button'
 import { cookies, headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { getAllNotes } from '@/lib/digital-garden'
@@ -79,12 +80,11 @@ export default async function DigitalGardenGraphPage() {
       <h1 className="mb-4 text-center text-3xl font-bold">{t('digital_garden.garden_graph')}</h1>
       <GraphWithSettings data={{ nodes, links }} tags={allTags} />
       <div className="mt-4 text-center">
-        <Link
-          href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}
-          className="text-blue-600 hover:underline"
-        >
-          {t('digital_garden.back')}
-        </Link>
+        <Button asChild variant="outline">
+          <Link href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}>
+            {t('digital_garden.back')}
+          </Link>
+        </Button>
       </div>
     </div>
   )

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -5,6 +5,8 @@ import path from "path"
 import { marked } from "marked"
 import matter from "gray-matter"
 import type { Metadata } from "next"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
 import { getSettings } from "@/lib/settings"
 import en from "@/locales/en.json"
 import es from "@/locales/es.json"
@@ -71,6 +73,8 @@ export default async function ProjectPage({ params }: { params: { slug: string }
     website: locale === "es" ? "Sitio web" : "Website",
   }
 
+  const backText = locale === "es" ? "← Volver a Proyectos" : "← Back to Projects"
+
   return (
     <div className="container mx-auto max-w-3xl px-4 py-8">
       <article className="prose dark:prose-invert">
@@ -103,6 +107,11 @@ export default async function ProjectPage({ params }: { params: { slug: string }
         )}
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </article>
+      <div className="mt-8">
+        <Button asChild variant="outline">
+          <Link href={locale === 'es' ? '/es/projects' : '/projects'}>{backText}</Link>
+        </Button>
+      </div>
     </div>
   )
 }

--- a/components/wiki-graph.tsx
+++ b/components/wiki-graph.tsx
@@ -88,13 +88,20 @@ export default function WikiGraph({
 
     const link = g
       .append('g')
-      .attr('stroke', linkColor)
       .attr('stroke-opacity', 0.6)
       .selectAll('line')
       .data(links)
       .enter()
       .append('line')
       .attr('stroke-width', settings.linkWidth)
+      .attr('stroke', (d: any) => {
+        const src =
+          typeof d.source === 'string'
+            ? nodes.find((n) => n.id === d.source)
+            : (d.source as any)
+        const tag = src?.tags[0]
+        return settings.tagColors[tag] || linkColor
+      })
 
     if (settings.showArrows) {
       link.attr('marker-end', 'url(#arrow)')


### PR DESCRIPTION
## Summary
- color graph links based on tag colors and allow customization in settings
- convert digital garden, blog, and project back links to styled buttons for consistent navigation

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68950ddef3d08326b859328d2d9fe503