### PR TITLE
feat: add contact page metadata

### DIFF
--- a/app/contact/layout.tsx
+++ b/app/contact/layout.tsx
@@ -1,0 +1,45 @@
+import type React from "react"
+import type { Metadata } from "next"
+import { cookies } from "next/headers"
+import { getCanonicalUrl } from "@/utils/getCanonicalUrl"
+import en from "@/locales/en.json"
+import es from "@/locales/es.json"
+
+export const revalidate = 60 * 60 * 24
+
+const translations = { en, es } as const
+
+export async function generateMetadata(): Promise<Metadata> {
+  const cookieStore = cookies()
+  const locale = (cookieStore.get("NEXT_LOCALE")?.value as "en" | "es") || "en"
+  const dict = translations[locale]
+  const siteUrl = getCanonicalUrl()
+  const url = locale === "es" ? `${siteUrl}/es/contact` : `${siteUrl}/contact`
+  const title = dict.contact.metadata.title
+  const description = dict.contact.metadata.description
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+      languages: {
+        en: `${siteUrl}/contact`,
+        es: `${siteUrl}/es/contact`,
+      },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+    },
+    twitter: {
+      title,
+      description,
+    },
+  }
+}
+
+export default function ContactLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -23,6 +23,10 @@
     "garden": "🌱 Garden"
   },
   "contact": {
+    "metadata": {
+      "title": "Contact - Fabricio",
+      "description": "Get in touch with Fabricio using the form or send a secure Nostr DM."
+    },
     "configuration_error_title": "Configuration Error",
     "configuration_error_description": "No Nostr public key configured. Please contact the site administrator.",
     "message_sent_title": "Message Sent Successfully!",

--- a/locales/es.json
+++ b/locales/es.json
@@ -23,6 +23,10 @@
     "garden": "🌱 Jardín"
   },
   "contact": {
+    "metadata": {
+      "title": "Contacto - Fabricio",
+      "description": "Envíale un mensaje a Fabricio de forma segura vía Nostr o correo."
+    },
     "configuration_error_title": "Error de configuración",
     "configuration_error_description": "No hay una clave pública de Nostr configurada. Por favor contacte al administrador del sitio.",
     "message_sent_title": "¡Mensaje enviado con éxito!",


### PR DESCRIPTION
## Summary
- add layout with metadata for contact page
- add English and Spanish translations for contact metadata

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689515c0ea6c8326a66104867007b92c