### PR TITLE
Fix digital garden graph link detection

### DIFF
--- a/app/digital-garden/graph/page.tsx
+++ b/app/digital-garden/graph/page.tsx
@@ -64,8 +64,8 @@ export default async function DigitalGardenGraphPage() {
   const notes = await getAllNotes(locale)
   const nodes = notes.map((n) => ({ id: n.slug, title: n.title, tags: n.tags }))
   const links: { source: string; target: string }[] = []
-  const linkRegex = /\[\[([^\]]+)\]\]/g
   for (const note of notes) {
+    const linkRegex = /\[\[([^\]]+)\]\]/g
     let match: RegExpExecArray | null
     while ((match = linkRegex.exec(note.content)) !== null) {
       const target = slugify(match[1])


### PR DESCRIPTION
## Summary
- ensure wiki link regex resets for each note so all connections are discovered

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689525234c74832685f632117ff43c62