### PR TITLE
Fix digital garden graph link detection

### DIFF
--- a/app/digital-garden/graph/page.tsx
+++ b/app/digital-garden/graph/page.tsx
@@ -66,6 +66,7 @@ export default async function DigitalGardenGraphPage() {
   const links: { source: string; target: string }[] = []
   const linkRegex = /\[\[([^\]]+)\]\]/g
   for (const note of notes) {
+    linkRegex.lastIndex = 0
     let match: RegExpExecArray | null
     while ((match = linkRegex.exec(note.content)) !== null) {
       const target = slugify(match[1])


### PR DESCRIPTION
## Summary
- reset wiki link regex before each note so all graph connections are detected without reloads

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689525234c74832685f632117ff43c62