### PR TITLE
Add local graph to digital garden notes

### DIFF
--- a/app/digital-garden/[slug]/page.tsx
+++ b/app/digital-garden/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { getSiteName } from '@/lib/settings'
 import { Badge } from '@/components/ui/badge'
 import { slugify } from '@/lib/slugify'
 import MissingNote from '@/components/MissingNote'
+import LocalGraph from '@/components/local-graph'
 import en from '@/locales/en.json'
 import es from '@/locales/es.json'
 
@@ -84,6 +85,39 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
     return <MissingNote slug={params.slug} locale={locale} />
   }
   const existingSlugs = new Set(notes.map((n) => n.slug))
+  const outgoing = new Set<string>()
+  const linkPattern = /\[\[([^\]]+)\]\]/g
+  let match: RegExpExecArray | null
+  while ((match = linkPattern.exec(note.content)) !== null) {
+    const slug = slugify(match[1])
+    if (existingSlugs.has(slug)) {
+      outgoing.add(slug)
+    }
+  }
+  const incoming = new Set<string>()
+  for (const other of notes) {
+    if (other.slug === note.slug) continue
+    const regex = /\[\[([^\]]+)\]\]/g
+    let m: RegExpExecArray | null
+    while ((m = regex.exec(other.content)) !== null) {
+      if (slugify(m[1]) === note.slug) {
+        incoming.add(other.slug)
+        break
+      }
+    }
+  }
+  const neighbors = Array.from(new Set([...outgoing, ...incoming]))
+  const graphNodes = [
+    { id: note.slug, title: note.title, tags: note.tags },
+    ...neighbors.map((slug) => {
+      const n = notes.find((nn) => nn.slug === slug)!
+      return { id: n.slug, title: n.title, tags: n.tags }
+    }),
+  ]
+  const graphLinks = [
+    ...Array.from(outgoing).map((target) => ({ source: note.slug, target })),
+    ...Array.from(incoming).map((source) => ({ source, target: note.slug })),
+  ]
   let content = note.content.replace(/\[\[([^\]]+)\]\]/g, (_match, p1) => {
     const slug = slugify(p1)
     const base = locale === 'es' ? '/es/digital-garden' : '/digital-garden'
@@ -122,6 +156,11 @@ export default async function DigitalGardenNotePage({ params }: { params: { slug
         )}
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </article>
+      {graphNodes.length > 1 && (
+        <div className="mt-8">
+          <LocalGraph data={{ nodes: graphNodes, links: graphLinks }} />
+        </div>
+      )}
       <div className="mt-8">
         <Button asChild variant="outline">
           <Link href={locale === 'es' ? '/es/digital-garden' : '/digital-garden'}>

--- a/components/local-graph.tsx
+++ b/components/local-graph.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import WikiGraph from '@/components/wiki-graph'
+
+interface GraphData {
+  nodes: { id: string; title: string; tags: string[] }[]
+  links: { source: string; target: string }[]
+}
+
+export default function LocalGraph({ data }: { data: GraphData }) {
+  const settings = {
+    showArrows: false,
+    textFadeThreshold: 1,
+    nodeSize: 6,
+    linkWidth: 1,
+    centerForce: 0.3,
+    chargeForce: -100,
+    linkForce: 1,
+    linkDistance: 80,
+    tagColors: {},
+    hiddenTags: [],
+  }
+
+  return <WikiGraph data={data} settings={settings} height={300} />
+}

--- a/components/wiki-graph.tsx
+++ b/components/wiki-graph.tsx
@@ -26,9 +26,11 @@ interface Settings {
 export default function WikiGraph({
   data,
   settings,
+  height = 600,
 }: {
   data: GraphData
   settings: Settings
+  height?: number
 }) {
   const ref = useRef<SVGSVGElement>(null)
   const { resolvedTheme } = useTheme()
@@ -37,7 +39,6 @@ export default function WikiGraph({
   useEffect(() => {
     const svg = d3.select(ref.current)
     const width = ref.current?.clientWidth || 800
-    const height = 600
     svg.attr('viewBox', `0 0 ${width} ${height}`)
     svg.selectAll('*').remove()
 
@@ -236,8 +237,8 @@ export default function WikiGraph({
     return () => {
       simulation.stop()
     }
-  }, [data, resolvedTheme, locale, settings])
+  }, [data, resolvedTheme, locale, settings, height])
 
-  return <svg ref={ref} className="h-[600px] w-full"></svg>
+  return <svg ref={ref} className="w-full" style={{ height }}></svg>
 }
 


### PR DESCRIPTION
## Summary
- show a small local graph on each digital garden note
- support custom graph height in WikiGraph component

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689549d96d908326ad4815de4f78b2ae