### PR TITLE
Respect URL locale when restoring from localStorage

### DIFF
--- a/components/locale-provider.tsx
+++ b/components/locale-provider.tsx
@@ -48,10 +48,19 @@ export function I18nProvider({
     if (typeof window !== "undefined") {
       const stored = localStorage.getItem("locale")
       if (stored === "en" || stored === "es") {
-        setLocale(stored as Locale)
+        const path = window.location.pathname
+        const segment = path.split("/")[1]
+        const pathLocale = segment === "en" || segment === "es" ? segment : null
+        const currentLocale = pathLocale ?? initialLocale
+
+        if (!pathLocale || stored === pathLocale) {
+          if (stored !== currentLocale) {
+            setLocale(stored as Locale)
+          }
+        }
       }
     }
-  }, [])
+  }, [initialLocale])
 
   useEffect(() => {
     if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary
- prevent localStorage locale from overriding explicit URL locale
- avoid resetting locale when stored value conflicts with cookie or path

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689563b15c4483268467ef12e607a5ce