### PR TITLE
Add digital garden metadata descriptions

### DIFF
--- a/app/digital-garden/page.tsx
+++ b/app/digital-garden/page.tsx
@@ -29,8 +29,10 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || `${protocol}://${host}`
   const url = locale === 'es' ? `${siteUrl}/es/digital-garden` : `${siteUrl}/digital-garden`
   const title = `${siteName}'s ${translations.en.navbar.garden}`
+  const description = translations[locale].digital_garden.metadata.description
   return {
     title,
+    description,
     alternates: {
       canonical: url,
       languages: {
@@ -40,12 +42,14 @@ export async function generateMetadata(): Promise<Metadata> {
     },
     openGraph: {
       title,
+      description,
       url,
       type: 'website',
       images: ['/digital-garden.png'],
     },
     twitter: {
       title,
+      description,
       images: ['/digital-garden.png'],
     },
   }

--- a/locales/en.json
+++ b/locales/en.json
@@ -97,6 +97,9 @@
     }
   },
   "digital_garden": {
+    "metadata": {
+      "description": "Explore Fabricio's evolving digital garden—interlinked notes on tech, Bitcoin and more."
+    },
     "graph_view": "Graph View",
     "all": "All",
     "garden_graph": "Garden Graph",

--- a/locales/es.json
+++ b/locales/es.json
@@ -97,6 +97,9 @@
     }
   },
   "digital_garden": {
+    "metadata": {
+      "description": "Explora el jardín digital en constante crecimiento de Fabricio: notas interconectadas sobre tecnología, Bitcoin y más."
+    },
     "graph_view": "Vista de Grafo",
     "all": "Todo",
     "garden_graph": "Grafo del Jardín",


### PR DESCRIPTION
## Summary
- add English and Spanish descriptions for the digital garden
- include description in digital garden metadata

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689563929450832691f0df1fffb1111c