### PR TITLE
Add local graph to digital garden notes

### DIFF
--- a/components/local-graph.tsx
+++ b/components/local-graph.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useMemo } from 'react'
+import WikiGraph from '@/components/wiki-graph'
+import * as d3 from 'd3'
+
+interface Node {
+  id: string
+  title: string
+  tags: string[]
+}
+
+interface Link {
+  source: string
+  target: string
+}
+
+export default function LocalGraph({
+  nodes,
+  links,
+}: {
+  nodes: Node[]
+  links: Link[]
+}) {
+  const settings = useMemo(() => {
+    const palette = d3.schemeCategory10
+    const tagColors: Record<string, string> = {}
+    const tags = Array.from(new Set(nodes.flatMap((n) => n.tags)))
+    tags.forEach((tag, i) => {
+      tagColors[tag] = palette[i % palette.length]
+    })
+    return {
+      showArrows: false,
+      textFadeThreshold: 2,
+      nodeSize: 6,
+      linkWidth: 1,
+      centerForce: 0.3,
+      chargeForce: -100,
+      linkForce: 1,
+      linkDistance: 60,
+      tagColors,
+      hiddenTags: [],
+    }
+  }, [nodes])
+
+  return <WikiGraph data={{ nodes, links }} settings={settings} height={192} />
+}
+

--- a/components/wiki-graph.tsx
+++ b/components/wiki-graph.tsx
@@ -26,9 +26,11 @@ interface Settings {
 export default function WikiGraph({
   data,
   settings,
+  height = 500,
 }: {
   data: GraphData
   settings: Settings
+  height?: number
 }) {
   const ref = useRef<SVGSVGElement>(null)
   const { resolvedTheme } = useTheme()
@@ -37,8 +39,8 @@ export default function WikiGraph({
   useEffect(() => {
     const svg = d3.select(ref.current)
     const width = ref.current?.clientWidth || 800
-    const height = 500
-    svg.attr('viewBox', `0 0 ${width} ${height}`)
+    const h = height
+    svg.attr('viewBox', `0 0 ${width} ${h}`)
     svg.selectAll('*').remove()
 
     const isDark = resolvedTheme === 'dark'
@@ -245,8 +247,8 @@ export default function WikiGraph({
     return () => {
       simulation.stop()
     }
-  }, [data, resolvedTheme, locale, settings])
+  }, [data, resolvedTheme, locale, settings, height])
 
-  return <svg ref={ref} className="h-[500px] w-full"></svg>
+  return <svg ref={ref} style={{ height }} className="w-full"></svg>
 }
 


### PR DESCRIPTION
## Summary
- allow WikiGraph to render at configurable heights
- add LocalGraph component for compact note graphs
- display small local graph on each digital garden note

## Testing
- `npm test` *(fails: Missing script "test")*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68955e5767548326b4a3ea0e129cba27